### PR TITLE
Backfill pocket timestamp defaults during sync

### DIFF
--- a/app/src/main/java/com/jayteealao/trails/data/local/database/PocketDao.kt
+++ b/app/src/main/java/com/jayteealao/trails/data/local/database/PocketDao.kt
@@ -149,6 +149,13 @@ interface PocketDao {
         """)
     fun countArticle(): Int
 
+    @Query("""
+        UPDATE pocketarticle
+        SET timeAdded = :time, timeUpdated = :time
+        WHERE timeAdded = 0 AND timeUpdated = 0
+        """)
+    suspend fun backfillZeroTimestamps(time: Long)
+
 //    @Upsert
 //    suspend fun insertPocketSummary(pocketSummary: PocketSummary)
 //

--- a/app/src/main/java/com/jayteealao/trails/sync/workers/SyncWorker.kt
+++ b/app/src/main/java/com/jayteealao/trails/sync/workers/SyncWorker.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.withContext
 import me.saket.unfurl.Unfurler
 import timber.log.Timber
 import javax.inject.Inject
+import java.util.concurrent.TimeUnit
 
 
 /**
@@ -74,6 +75,9 @@ class SyncWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(Dispatchers.IO){
         val syncJob: Job?
         var hadErrors = false
+
+        val yesterday = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1)
+        pocketDao.backfillZeroTimestamps(yesterday)
 
         setForeground(getForegroundInfo())
             syncJob = launch(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- add PocketDao.backfillZeroTimestamps to update missing timestamps
- call backfillZeroTimestamps at start of SyncWorker.doWork

## Testing
- ⚠️ `./gradlew test` *(failed: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ffec39483239f9fdf61eb7b70dc