### PR TITLE
Harden Firestore/GCS access (groundwork) and cut Durable Objects cost

### DIFF
--- a/.github/workflows/firebase-rules.yml
+++ b/.github/workflows/firebase-rules.yml
@@ -49,7 +49,7 @@ jobs:
             firebase-emulators-${{ runner.os }}-
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Firestore rules tests (emulator)
         run: npm test

--- a/.github/workflows/firebase-rules.yml
+++ b/.github/workflows/firebase-rules.yml
@@ -70,29 +70,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for Firebase token
-        id: has_token
         env:
           TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
-          if [ -n "$TOKEN" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "FIREBASE_TOKEN secret not set; skipping deploy."
+          if [ -z "$TOKEN" ]; then
+            echo "::error::FIREBASE_TOKEN required to deploy on push/dispatch but secret is not set."
+            exit 1
           fi
 
       - name: Setup Node
-        if: steps.has_token.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install firebase-tools
-        if: steps.has_token.outputs.present == 'true'
         run: npm install -g firebase-tools
 
       - name: Deploy Firestore + Storage rules
-        if: steps.has_token.outputs.present == 'true'
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |

--- a/.github/workflows/firebase-rules.yml
+++ b/.github/workflows/firebase-rules.yml
@@ -7,11 +7,58 @@ on:
     paths:
       - 'firebase/**'
       - '.github/workflows/firebase-rules.yml'
+  pull_request:
+    paths:
+      - 'firebase/**'
+      - '.github/workflows/firebase-rules.yml'
   workflow_dispatch:
 
 jobs:
+  # Validate the ruleset against the Firestore emulator before it can be
+  # deployed. This job gates deploy-rules and also runs on pull requests so a
+  # broken ruleset is caught before merge.
+  rules-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: firebase/test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Java (Firestore emulator runtime)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Firebase emulator binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-${{ runner.os }}-${{ hashFiles('firebase/test/package.json') }}
+          restore-keys: |
+            firebase-emulators-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Firestore rules tests (emulator)
+        run: npm test
+
   deploy-rules:
     runs-on: ubuntu-latest
+    # Never deploy from a pull request; only push-to-main and manual dispatch.
+    if: github.event_name != 'pull_request'
+    needs: rules-test
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/warg-ci.yml
+++ b/.github/workflows/warg-ci.yml
@@ -68,6 +68,13 @@ jobs:
           # without a typecheck script instead of failing.
           pnpm -r --if-present run typecheck
 
+      - name: Unit tests — backfill-scripts (pure, no emulator)
+        # Scoped to the one package with a CI-safe pure test suite (node:test).
+        # The package's emulator-backed integration suite needs Java + the
+        # Firestore emulator and is run on demand, not here. Broaden to a
+        # workspace-wide `pnpm -r test` once other packages have CI-safe suites.
+        run: pnpm --filter @warg/backfill-scripts test
+
   shared-types-drift:
     # Runs unconditionally when warg-ci is triggered. The workflow-level
     # paths filter already gates this to PRs that touch warg/firebase/shared-types.

--- a/.github/workflows/warg-ci.yml
+++ b/.github/workflows/warg-ci.yml
@@ -59,7 +59,6 @@ jobs:
 
       - name: Lint
         run: pnpm exec eslint . --max-warnings=0
-        continue-on-error: true  # legacy code may have lint debt; promote to required once clean
 
       - name: Typecheck all workspace packages
         run: |

--- a/.github/workflows/warg-ci.yml
+++ b/.github/workflows/warg-ci.yml
@@ -68,12 +68,14 @@ jobs:
           # without a typecheck script instead of failing.
           pnpm -r --if-present run typecheck
 
-      - name: Unit tests — backfill-scripts (pure, no emulator)
-        # Scoped to the one package with a CI-safe pure test suite (node:test).
-        # The package's emulator-backed integration suite needs Java + the
-        # Firestore emulator and is run on demand, not here. Broaden to a
-        # workspace-wide `pnpm -r test` once other packages have CI-safe suites.
-        run: pnpm --filter @warg/backfill-scripts test
+      - name: Unit tests — all workspace packages
+        # Runs vitest (node-env) suites across workers/*, packages/*, pages/*,
+        # plus workers/logger (Cloudflare Workers pool via workerd), plus
+        # cloud-functions node:test suites. Integration suites that need the
+        # Firestore emulator are scoped to *.integration.test.* and excluded
+        # by each package's own test script. firebase/test lives outside the
+        # pnpm workspace and is not included.
+        run: pnpm -r --if-present run test
 
   shared-types-drift:
     # Runs unconditionally when warg-ci is triggered. The workflow-level

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ warg/scripts/gcs-ids.txt
 warg/scripts/*-audit.csv
 warg/scripts/export-articles-csv.mjs
 
+Analytics _ Dashboards _ Jayteealao@gmail.PDF
+firebase/test/node_modules/**/*
+firebase/test/firestore-debug.log

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -331,6 +331,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation("io.mockk:mockk:1.14.5")
+    // Provides Tasks + Task.await() on the unit-test classpath (version-aligned
+    // with kotlinx-coroutines-test) so Firestore Task mocks resolve correctly.
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 
     // Instrumented tests: jUnit rules and runners
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -135,6 +135,15 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    testOptions {
+        unitTests {
+            // Firebase enums (e.g. FirebaseFirestoreException.Code) statically
+            // touch android.util.SparseArray; without this their <clinit> throws
+            // "not mocked" under plain JVM unit tests.
+            isReturnDefaultValues = true
+        }
+    }
+
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -230,6 +230,7 @@ dependencies {
     implementation(libs.firebase.ai)
     implementation(libs.firebase.auth)
     implementation(libs.firebase.firestore)
+    implementation(libs.firebase.config)
     implementation(libs.play.services.auth)
 
     // Navigation 3

--- a/android/app/src/main/java/com/jayteealao/trails/Trails.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/Trails.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 
 @HiltAndroidApp
 class Trails @Inject constructor() : Application(), Configuration.Provider, SingletonImageLoader.Factory {
@@ -41,6 +42,7 @@ class Trails @Inject constructor() : Application(), Configuration.Provider, Sing
     @Inject lateinit var workerFactory: HiltWorkerFactory
     @Inject lateinit var firestoreSyncManager: FirestoreSyncManager
     @Inject lateinit var auth: FirebaseAuth
+    @Inject lateinit var firestoreLogTreeProvider: Provider<FirestoreLogTree>
 
 //    override val workManagerConfiguration: Configuration = Configuration.Builder()
 
@@ -50,7 +52,7 @@ class Trails @Inject constructor() : Application(), Configuration.Provider, Sing
 //        Sync.initialize(context = this)
         Timber.plant(Timber.DebugTree())
         if (BuildConfig.DEBUG) {
-            Timber.plant(FirestoreLogTree())
+            Timber.plant(firestoreLogTreeProvider.get())
         }
 
         // Schedule periodic sync AFTER Hilt dependency injection completes

--- a/android/app/src/main/java/com/jayteealao/trails/common/FirestoreLogTree.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/common/FirestoreLogTree.kt
@@ -1,27 +1,35 @@
 package com.jayteealao.trails.common
 
 import android.util.Log
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Debug-only Timber tree that aggregates log entries per article session in Firestore.
  *
- * Structure: debug_logs/{sessionId}_{articleId}
+ * Structure: debug_logs/{uid}/sessions/{sessionId}_{articleId}
  *   - sessionId, articleId, device, enteredAt
  *   - events: [ { ts, tag, msg, level, error? }, ... ]
  *
- * Only logs from archive-related tags are forwarded.
+ * Owner-scoped under the signed-in user's uid (matches the firestore.rules
+ * `debug_logs/{userId}/sessions/{sessionId}` match). Logging is skipped when no
+ * user is signed in. Only logs from archive-related tags are forwarded.
  * Article ID is extracted from log message patterns like method(articleId).
  */
-class FirestoreLogTree : Timber.DebugTree() {
+@Singleton
+class FirestoreLogTree @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val auth: FirebaseAuth,
+) : Timber.DebugTree() {
 
     private val sessionId = UUID.randomUUID().toString().take(8)
-    private val firestore = FirebaseFirestore.getInstance()
     private val articleDocs = ConcurrentHashMap<String, DocumentReference>()
 
     private val relevantTags = setOf(
@@ -40,8 +48,10 @@ class FirestoreLogTree : Timber.DebugTree() {
         val isRelevant = tag != null && relevantTags.any { tag.contains(it) }
         if (!isRelevant) return
 
+        // Owner-scoped path requires a signed-in uid; skip otherwise.
+        val uid = auth.currentUser?.uid ?: return
         val articleId = extractArticleId(message) ?: "session"
-        val docRef = getOrCreateDoc(articleId)
+        val docRef = getOrCreateDoc(uid, articleId)
 
         val event = mutableMapOf<String, Any>(
             "ts" to System.currentTimeMillis(),
@@ -62,10 +72,13 @@ class FirestoreLogTree : Timber.DebugTree() {
         return id.ifEmpty { null }
     }
 
-    private fun getOrCreateDoc(articleId: String): DocumentReference {
+    private fun getOrCreateDoc(uid: String, articleId: String): DocumentReference {
         return articleDocs.getOrPut(articleId) {
             val docId = "${sessionId}_${articleId}"
-            val ref = firestore.collection("debug_logs").document(docId)
+            val ref = firestore.collection("debug_logs")
+                .document(uid)
+                .collection("sessions")
+                .document(docId)
             ref.set(
                 mapOf(
                     "sessionId" to sessionId,

--- a/android/app/src/main/java/com/jayteealao/trails/common/FirestoreLogTree.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/common/FirestoreLogTree.kt
@@ -73,7 +73,8 @@ class FirestoreLogTree @Inject constructor(
     }
 
     private fun getOrCreateDoc(uid: String, articleId: String): DocumentReference {
-        return articleDocs.getOrPut(articleId) {
+        val cacheKey = "$uid/$articleId"
+        return articleDocs.getOrPut(cacheKey) {
             val docId = "${sessionId}_${articleId}"
             val ref = firestore.collection("debug_logs")
                 .document(uid)

--- a/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
@@ -7,13 +7,19 @@ import android.util.Base64
 import com.google.android.gms.auth.GoogleAuthUtil
 import com.google.android.gms.auth.UserRecoverableAuthException
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.firestore.ListenerRegistration
 import com.jayteealao.trails.common.di.dispatchers.Dispatcher
 import com.jayteealao.trails.common.di.dispatchers.TrailsDispatchers
 import com.jayteealao.trails.data.local.database.ArticleDao
+import com.jayteealao.trails.services.firestore.FirestoreBackupService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.flow.Flow
@@ -50,6 +56,8 @@ private const val THUMBNAIL_QUALITY = 80
 @Singleton
 class ArchiveService @Inject constructor(
     private val firestore: FirebaseFirestore,
+    private val auth: FirebaseAuth,
+    private val backupService: FirestoreBackupService,
     private val okHttpClient: OkHttpClient,
     private val localArchiveDao: LocalArchiveDao,
     private val articleDao: ArticleDao,
@@ -67,31 +75,55 @@ class ArchiveService @Inject constructor(
     fun observeRemoteArchives(itemId: String): Flow<Map<String, ArchiveStatus>> = callbackFlow {
         Timber.d("observeRemoteArchives($itemId) — attaching Firestore listener")
         val docRef = firestore.collection("articles").document(itemId)
-        val listener = docRef.addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                Timber.e(error, "observeRemoteArchives($itemId) — listener error")
-                return@addSnapshotListener
-            }
-            if (snapshot == null || !snapshot.exists()) {
-                Timber.d("observeRemoteArchives($itemId) — doc missing or null, emitting empty")
-                trySend(emptyMap())
-                return@addSnapshotListener
-            }
+        var hasSelfHealed = false
+        var registration: ListenerRegistration? = null
 
-            val archives = mutableMapOf<String, ArchiveStatus>()
-            @Suppress("UNCHECKED_CAST")
-            val archivesMap = snapshot.get("archives") as? Map<String, Map<String, Any>> ?: emptyMap()
-            for ((key, value) in archivesMap) {
-                val status = value["status"] as? String ?: continue
-                val gcsPath = value["gcs_path"] as? String
-                archives[key] = ArchiveStatus(status, gcsPath)
+        fun attach() {
+            registration = docRef.addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    // Self-heal once on a denied read for an article we own:
+                    // write the existence marker and re-attach the listener.
+                    if (error.code == FirebaseFirestoreException.Code.PERMISSION_DENIED &&
+                        !hasSelfHealed && auth.currentUser != null
+                    ) {
+                        hasSelfHealed = true
+                        Timber.w(error, "observeRemoteArchives($itemId) — read denied, self-healing marker")
+                        launch {
+                            backupService.writeArticleMarker(itemId)
+                            registration?.remove()
+                            attach()
+                        }
+                        return@addSnapshotListener
+                    }
+                    // Unrecoverable (or already healed): surface a graceful empty
+                    // state instead of leaving the flow hanging — never crash.
+                    Timber.e(error, "observeRemoteArchives($itemId) — listener error, emitting empty")
+                    trySend(emptyMap())
+                    return@addSnapshotListener
+                }
+                if (snapshot == null || !snapshot.exists()) {
+                    Timber.d("observeRemoteArchives($itemId) — doc missing or null, emitting empty")
+                    trySend(emptyMap())
+                    return@addSnapshotListener
+                }
+
+                val archives = mutableMapOf<String, ArchiveStatus>()
+                @Suppress("UNCHECKED_CAST")
+                val archivesMap = snapshot.get("archives") as? Map<String, Map<String, Any>> ?: emptyMap()
+                for ((key, value) in archivesMap) {
+                    val status = value["status"] as? String ?: continue
+                    val gcsPath = value["gcs_path"] as? String
+                    archives[key] = ArchiveStatus(status, gcsPath)
+                }
+                Timber.d("observeRemoteArchives($itemId) — emitting ${archives.size} archives: ${archives.map { "${it.key}=${it.value.status}" }}")
+                trySend(archives)
             }
-            Timber.d("observeRemoteArchives($itemId) — emitting ${archives.size} archives: ${archives.map { "${it.key}=${it.value.status}" }}")
-            trySend(archives)
         }
+
+        attach()
         awaitClose {
             Timber.d("observeRemoteArchives($itemId) — listener removed")
-            listener.remove()
+            registration?.remove()
         }
     }
 
@@ -215,6 +247,37 @@ class ArchiveService @Inject constructor(
         Timber.d("syncArchives($itemId) — all downloads complete")
     }
 
+    // ── Top-level article read with self-heal ───────────────────────────
+
+    /**
+     * Read the top-level articles/{itemId} doc, self-healing once on a
+     * PERMISSION_DENIED: write the owner's existence marker for [itemId] and
+     * retry the read a single time. Returns null on a missing doc or an
+     * unrecoverable failure — callers surface a graceful unavailable state and
+     * never crash. The `articles` read rule is not yet tightened, so this path
+     * is proven by unit test now and exercised end-to-end once it is tightened.
+     */
+    private suspend fun getArticleDocWithSelfHeal(itemId: String): DocumentSnapshot? {
+        val docRef = firestore.collection("articles").document(itemId)
+        var hasSelfHealed = false
+        while (true) {
+            try {
+                return docRef.get().await()
+            } catch (e: FirebaseFirestoreException) {
+                if (e.code == FirebaseFirestoreException.Code.PERMISSION_DENIED &&
+                    !hasSelfHealed && auth.currentUser != null
+                ) {
+                    hasSelfHealed = true
+                    Timber.w(e, "getArticleDoc($itemId) — read denied, writing marker and retrying once")
+                    backupService.writeArticleMarker(itemId)
+                    continue
+                }
+                Timber.w(e, "getArticleDoc($itemId) — read failed (${e.code}), surfacing unavailable")
+                return null
+            }
+        }
+    }
+
     // ── e) Screenshot → image fallback ──────────────────────────────────
 
     suspend fun applyScreenshotAsImage(itemId: String) = withContext(ioDispatcher) {
@@ -223,7 +286,7 @@ class ArchiveService @Inject constructor(
         if (article != null && !article.image.isNullOrBlank()) return@withContext
 
         // Fetch remote archive status to get screenshot gcs_path
-        val doc = firestore.collection("articles").document(itemId).get().await()
+        val doc = getArticleDocWithSelfHeal(itemId) ?: return@withContext
         if (!doc.exists()) return@withContext
 
         @Suppress("UNCHECKED_CAST")
@@ -273,7 +336,7 @@ class ArchiveService @Inject constructor(
     // ── f) Metadata fetch ───────────────────────────────────────────────
 
     suspend fun fetchWargMetadata(itemId: String): WargMetadata? = withContext(ioDispatcher) {
-        val doc = firestore.collection("articles").document(itemId).get().await()
+        val doc = getArticleDocWithSelfHeal(itemId) ?: return@withContext null
         if (!doc.exists()) return@withContext null
 
         @Suppress("UNCHECKED_CAST")

--- a/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
@@ -386,7 +386,12 @@ class ArchiveService @Inject constructor(
             return null
         }
 
-        val token = user.getIdToken(false).await().token
+        val token = try {
+            user.getIdToken(false).await().token
+        } catch (e: Exception) {
+            Timber.w(e, "downloadArchive($itemId, $archiveKey) — getIdToken failed, skipping")
+            return null
+        }
         if (token == null) {
             Timber.w("downloadArchive($itemId, $archiveKey) — null ID token, skipping")
             return null

--- a/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
@@ -73,6 +73,24 @@ class ArchiveService @Inject constructor(
     /** Limit concurrent archive downloads to cap peak memory from parallel decompress. */
     private val downloadSemaphore = Semaphore(3)
 
+    /**
+     * Resolve the owning article's [Article.itemId] for a marker key that may be
+     * either an itemId or a resolvedId. The rules' getAfter check requires a doc
+     * at users/{uid}/articles/{itemId}, which only exists under the canonical
+     * itemId, not under a resolvedId alias.
+     *
+     * Strategy:
+     * 1. Try [articleDao.getArticleById] — fast path when [key] is already the itemId.
+     * 2. If null, try [articleDao.getArticleByResolvedId] — for resolvedId-keyed reads.
+     * 3. If still null (article not in local DB yet), fall back to [key] — the
+     *    marker write may still fail the rule, but it degrades to the existing
+     *    graceful empty state rather than crashing.
+     */
+    private suspend fun owningItemId(key: String): String =
+        articleDao.getArticleById(key)?.itemId
+            ?: articleDao.getArticleByResolvedId(key)?.itemId
+            ?: key
+
     // ── a) Firestore document listener ──────────────────────────────────
 
     fun observeRemoteArchives(itemId: String): Flow<Map<String, ArchiveStatus>> = callbackFlow {
@@ -94,9 +112,10 @@ class ArchiveService @Inject constructor(
                         hasSelfHealed = true
                         Timber.w(error, "observeRemoteArchives($itemId) — read denied, self-healing marker")
                         launch {
-                            val result = backupService.writeArticleMarker(itemId)
+                            val markerItemId = owningItemId(itemId)
+                            val result = backupService.writeArticleMarker(itemId, markerItemId)
                             result.onFailure { t ->
-                                Timber.w(t, "observeRemoteArchives($itemId) — self-heal marker write failed for $itemId")
+                                Timber.w(t, "observeRemoteArchives($itemId) — self-heal marker write failed for $itemId (markerItemId=$markerItemId)")
                             }
                             // Remove the stale registration and re-attach only if
                             // the producer scope is still alive; if the collector
@@ -279,9 +298,10 @@ class ArchiveService @Inject constructor(
                 ) {
                     hasSelfHealed = true
                     Timber.w(e, "getArticleDoc($itemId) — read denied, writing marker and retrying once")
-                    val result = backupService.writeArticleMarker(itemId)
+                    val markerItemId = owningItemId(itemId)
+                    val result = backupService.writeArticleMarker(itemId, markerItemId)
                     result.onFailure { t ->
-                        Timber.w(t, "getArticleDoc($itemId) — self-heal marker write failed for $itemId")
+                        Timber.w(t, "getArticleDoc($itemId) — self-heal marker write failed for $itemId (markerItemId=$markerItemId)")
                     }
                     continue
                 }

--- a/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
@@ -20,6 +20,7 @@ import com.jayteealao.trails.services.firestore.FirestoreBackupService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicReference
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
@@ -77,10 +79,12 @@ class ArchiveService @Inject constructor(
         Timber.d("observeRemoteArchives($itemId) — attaching Firestore listener")
         val docRef = firestore.collection("articles").document(itemId)
         var hasSelfHealed = false
-        var registration: ListenerRegistration? = null
+        // Single source of truth for the current registration, visible across the
+        // Firestore callback thread and the coroutine launched for self-heal.
+        val registrationRef = AtomicReference<ListenerRegistration?>(null)
 
         fun attach() {
-            registration = docRef.addSnapshotListener { snapshot, error ->
+            registrationRef.set(docRef.addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     // Self-heal once on a denied read for an article we own:
                     // write the existence marker and re-attach the listener.
@@ -90,9 +94,18 @@ class ArchiveService @Inject constructor(
                         hasSelfHealed = true
                         Timber.w(error, "observeRemoteArchives($itemId) — read denied, self-healing marker")
                         launch {
-                            backupService.writeArticleMarker(itemId)
-                            registration?.remove()
-                            attach()
+                            val result = backupService.writeArticleMarker(itemId)
+                            result.onFailure { t ->
+                                Timber.w(t, "observeRemoteArchives($itemId) — self-heal marker write failed for $itemId")
+                            }
+                            // Remove the stale registration and re-attach only if
+                            // the producer scope is still alive; if the collector
+                            // cancelled during the marker write we must not create
+                            // a new listener that would never be removed.
+                            registrationRef.getAndSet(null)?.remove()
+                            if (isActive) {
+                                attach()
+                            }
                         }
                         return@addSnapshotListener
                     }
@@ -118,13 +131,13 @@ class ArchiveService @Inject constructor(
                 }
                 Timber.d("observeRemoteArchives($itemId) — emitting ${archives.size} archives: ${archives.map { "${it.key}=${it.value.status}" }}")
                 trySend(archives)
-            }
+            })
         }
 
         attach()
         awaitClose {
             Timber.d("observeRemoteArchives($itemId) — listener removed")
-            registration?.remove()
+            registrationRef.getAndSet(null)?.remove()
         }
     }
 
@@ -266,7 +279,10 @@ class ArchiveService @Inject constructor(
                 ) {
                     hasSelfHealed = true
                     Timber.w(e, "getArticleDoc($itemId) — read denied, writing marker and retrying once")
-                    backupService.writeArticleMarker(itemId)
+                    val result = backupService.writeArticleMarker(itemId)
+                    result.onFailure { t ->
+                        Timber.w(t, "getArticleDoc($itemId) — self-heal marker write failed for $itemId")
+                    }
                     continue
                 }
                 Timber.w(e, "getArticleDoc($itemId) — read failed (${e.code}), surfacing unavailable")
@@ -387,7 +403,7 @@ class ArchiveService @Inject constructor(
             return null
         }
 
-        return fetchObjectBytes(signedUrl)
+        return withContext(ioDispatcher) { fetchObjectBytes(signedUrl) }
     }
 
     /**

--- a/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt
@@ -4,17 +4,18 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Base64
-import com.google.android.gms.auth.GoogleAuthUtil
-import com.google.android.gms.auth.UserRecoverableAuthException
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.jayteealao.trails.common.di.dispatchers.Dispatcher
 import com.jayteealao.trails.common.di.dispatchers.TrailsDispatchers
 import com.jayteealao.trails.data.local.database.ArticleDao
+import com.jayteealao.trails.di.ARCHIVE_SIGNED_URL_BASE_KEY
+import com.jayteealao.trails.di.DEFAULT_DASHBOARD_API_URL
+import com.jayteealao.trails.network.ArchiveUrlService
 import com.jayteealao.trails.services.firestore.FirestoreBackupService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
@@ -33,7 +34,6 @@ import timber.log.Timber
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.net.URLEncoder
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 import javax.inject.Inject
@@ -48,7 +48,6 @@ data class WargMetadata(
     val wordCount: Int?,
 )
 
-private const val GCS_BUCKET = "htbase-archives-standard"
 private const val MAX_DOWNLOAD_BYTES = 50L * 1024 * 1024 // 50MB
 private const val THUMBNAIL_SIZE = 160
 private const val THUMBNAIL_QUALITY = 80
@@ -59,6 +58,8 @@ class ArchiveService @Inject constructor(
     private val auth: FirebaseAuth,
     private val backupService: FirestoreBackupService,
     private val okHttpClient: OkHttpClient,
+    private val archiveUrlService: ArchiveUrlService,
+    private val remoteConfig: FirebaseRemoteConfig,
     private val localArchiveDao: LocalArchiveDao,
     private val articleDao: ArticleDao,
     private val application: Application,
@@ -132,11 +133,10 @@ class ArchiveService @Inject constructor(
     suspend fun downloadAndStoreArchive(
         itemId: String,
         type: ArchiveType,
-        gcsPath: String,
     ): LocalArchive? = withContext(ioDispatcher) {
-        Timber.d("downloadAndStore($itemId, ${type.archiveKey}) — fetching from GCS: $gcsPath")
+        Timber.d("downloadAndStore($itemId, ${type.archiveKey}) — fetching via signed URL")
 
-        val rawBytes = downloadFromGcs(gcsPath)
+        val rawBytes = downloadArchive(itemId, type.archiveKey)
         if (rawBytes == null) {
             Timber.w("downloadAndStore($itemId, ${type.archiveKey}) — download returned null, skipping")
             return@withContext null
@@ -234,10 +234,7 @@ class ArchiveService @Inject constructor(
             async {
                 downloadSemaphore.withPermit {
                     try {
-                        downloadAndStoreArchive(itemId, type, status.gcsPath)
-                    } catch (e: UserRecoverableAuthException) {
-                        Timber.w("Storage consent needed for ${type.archiveKey} download")
-                        throw e // Propagate so caller can handle consent UI
+                        downloadAndStoreArchive(itemId, type)
                     } catch (e: Exception) {
                         Timber.e(e, "Failed to download ${type.archiveKey} for $itemId")
                     }
@@ -295,10 +292,12 @@ class ArchiveService @Inject constructor(
 
         val status = screenshotEntry["status"] as? String
         val gcsPath = screenshotEntry["gcs_path"] as? String
+        // gcs_path presence is the readiness signal; the object is fetched via
+        // the scoped signed-URL path, not the gs:// path directly.
         if (status != "success" || gcsPath == null) return@withContext
 
         // Download screenshot PNG transiently
-        val rawBytes = downloadFromGcs(gcsPath)
+        val rawBytes = downloadArchive(itemId, "screenshot")
         if (rawBytes == null) {
             Timber.d("applyScreenshotAsImage($itemId) — screenshot download returned null")
             return@withContext
@@ -350,43 +349,65 @@ class ArchiveService @Inject constructor(
         )
     }
 
-    // ── GCS download via JSON API ──────────────────────────────────────
+    // ── Scoped archive download via per-user signed URL ─────────────────
 
-    private fun downloadFromGcs(gcsPath: String): ByteArray? {
-        val objectPath = gcsPath
-            .removePrefix("gs://$GCS_BUCKET/")
-            .removePrefix("gs://htbase-archives-standard/")
-        val encodedPath = URLEncoder.encode(objectPath, "UTF-8")
-        val url = "https://storage.googleapis.com/storage/v1/b/$GCS_BUCKET/o/$encodedPath?alt=media"
-
-        val googleAccount = GoogleSignIn.getLastSignedInAccount(application)?.account
-        if (googleAccount == null) {
-            Timber.w("downloadFromGcs — no Google account signed in")
+    /**
+     * Fetch an archive object via the scoped, owner-checked signed-URL path:
+     * exchange the signed-in user's Firebase ID token at `/app/signed-url` for a
+     * short-lived V4 signed GCS URL, then GET the object directly (the signed
+     * URL carries its own auth in the query string — no Authorization header).
+     *
+     * Returns null when the user is not signed in, the signing request fails, or
+     * the object fetch fails — callers degrade to a graceful unavailable state.
+     */
+    // internal (not private) so the signed-URL fetch path can be unit-tested
+    // directly without exercising the file-I/O / bitmap decode of the public
+    // callers (see ArchiveServiceFetchTest).
+    internal suspend fun downloadArchive(itemId: String, archiveKey: String): ByteArray? {
+        val user = auth.currentUser
+        if (user == null) {
+            Timber.w("downloadArchive($itemId, $archiveKey) — no signed-in user, skipping")
             return null
         }
-        // GoogleAuthUtil.getToken() may throw UserRecoverableAuthException — let it propagate
-        val accessToken = GoogleAuthUtil.getToken(
-            application,
-            googleAccount,
-            "oauth2:https://www.googleapis.com/auth/devstorage.read_only",
-        )
 
-        val request = Request.Builder()
-            .url(url)
-            .header("Authorization", "Bearer $accessToken")
-            .build()
+        val token = user.getIdToken(false).await().token
+        if (token == null) {
+            Timber.w("downloadArchive($itemId, $archiveKey) — null ID token, skipping")
+            return null
+        }
 
+        val base = remoteConfig.getString(ARCHIVE_SIGNED_URL_BASE_KEY)
+            .ifBlank { DEFAULT_DASHBOARD_API_URL }
+        val endpoint = "$base/app/signed-url"
+
+        val signedUrl = try {
+            archiveUrlService.getSignedUrl(endpoint, "Bearer $token", itemId, archiveKey).url
+        } catch (e: Exception) {
+            Timber.w(e, "downloadArchive($itemId, $archiveKey) — signed-URL request failed")
+            return null
+        }
+
+        return fetchObjectBytes(signedUrl)
+    }
+
+    /**
+     * GET an object URL with a bounded read (no Authorization header — the
+     * signed URL is self-authorizing). Enforces [MAX_DOWNLOAD_BYTES] whether or
+     * not the server reports a Content-Length.
+     */
+    private fun fetchObjectBytes(url: String): ByteArray? {
+        val request = Request.Builder().url(url).build()
         return try {
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    Timber.w("GCS download failed: HTTP ${response.code} for $objectPath")
+                    Timber.w("Signed-URL object fetch failed: HTTP ${response.code}")
                     return@use null
                 }
 
                 // Pre-check: reject before downloading if Content-Length is known and too large
                 val contentLength = response.header("Content-Length")?.toLongOrNull()
                 if (contentLength != null && contentLength > MAX_DOWNLOAD_BYTES) {
-                    Timber.w("GCS object too large: $contentLength bytes (limit: $MAX_DOWNLOAD_BYTES) for $objectPath")
+                    Timber.w("Archive object too large: $contentLength bytes (limit: $MAX_DOWNLOAD_BYTES)")
                     return@use null
                 }
 
@@ -399,14 +420,14 @@ class ArchiveService @Inject constructor(
                     if (bytesRead == -1L) break
                     totalRead += bytesRead
                     if (totalRead > MAX_DOWNLOAD_BYTES) {
-                        Timber.w("GCS download exceeded $MAX_DOWNLOAD_BYTES bytes, aborting for $objectPath")
+                        Timber.w("Archive download exceeded $MAX_DOWNLOAD_BYTES bytes, aborting")
                         return@use null
                     }
                 }
                 buffer.readByteArray()
             }
         } catch (e: java.io.IOException) {
-            Timber.w(e, "downloadFromGcs — network error for $objectPath")
+            Timber.w(e, "fetchObjectBytes — network error")
             null
         }
     }

--- a/android/app/src/main/java/com/jayteealao/trails/data/local/database/ArticleDao.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/local/database/ArticleDao.kt
@@ -135,7 +135,7 @@ interface ArticleDao {
     suspend fun getArticleById(itemId: String): Article?
 
     /** Look up an article whose resolvedId matches [resolvedId] (used by self-heal). */
-    @Query("SELECT * FROM article WHERE resolvedId = :resolvedId LIMIT 1")
+    @Query("SELECT * FROM article WHERE resolvedId = :resolvedId ORDER BY timeAdded DESC LIMIT 1")
     suspend fun getArticleByResolvedId(resolvedId: String): Article?
 
     @SuppressWarnings(RoomWarnings.Companion.QUERY_MISMATCH)

--- a/android/app/src/main/java/com/jayteealao/trails/data/local/database/ArticleDao.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/data/local/database/ArticleDao.kt
@@ -134,6 +134,10 @@ interface ArticleDao {
     @Query("SELECT * FROM article WHERE itemId = :itemId")
     suspend fun getArticleById(itemId: String): Article?
 
+    /** Look up an article whose resolvedId matches [resolvedId] (used by self-heal). */
+    @Query("SELECT * FROM article WHERE resolvedId = :resolvedId LIMIT 1")
+    suspend fun getArticleByResolvedId(resolvedId: String): Article?
+
     @SuppressWarnings(RoomWarnings.Companion.QUERY_MISMATCH)
     @RewriteQueriesToDropUnusedColumns
     @Query(

--- a/android/app/src/main/java/com/jayteealao/trails/di/RemoteConfigModule.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/di/RemoteConfigModule.kt
@@ -1,0 +1,36 @@
+package com.jayteealao.trails.di
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Remote Config key for the archive signed-URL endpoint base URL. */
+const val ARCHIVE_SIGNED_URL_BASE_KEY = "archive_signed_url_base"
+
+/**
+ * Default base URL for the `dashboardApi` Cloud Function. Baked in so the very
+ * first launch — before Remote Config finishes fetching/activating — still
+ * resolves a working endpoint. A Remote Config override applies on the next
+ * read without an app rebuild.
+ */
+const val DEFAULT_DASHBOARD_API_URL =
+    "https://us-central1-trails-e428e.cloudfunctions.net/dashboardApi"
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteConfigModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig {
+        return FirebaseRemoteConfig.getInstance().apply {
+            setDefaultsAsync(mapOf(ARCHIVE_SIGNED_URL_BASE_KEY to DEFAULT_DASHBOARD_API_URL))
+            // Kick off a fetch+activate at provide time; the baked default covers
+            // the window before it completes.
+            fetchAndActivate()
+        }
+    }
+}

--- a/android/app/src/main/java/com/jayteealao/trails/network/ArchiveUrlService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/network/ArchiveUrlService.kt
@@ -1,0 +1,27 @@
+package com.jayteealao.trails.network
+
+import com.jayteealao.trails.network.dto.SignedUrlResponse
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
+import retrofit2.http.Url
+
+/**
+ * Retrofit client for the per-user archive signed-URL endpoint
+ * (`GET /app/signed-url`) on the `dashboardApi` Cloud Function.
+ *
+ * The absolute URL is supplied per call via [Url] so the Remote-Config-driven
+ * base (see `RemoteConfigModule`) is applied without rebuilding Retrofit. The
+ * caller passes a Firebase ID token as the `Authorization: Bearer` header; the
+ * endpoint verifies it, confirms ownership, and returns a short-lived signed
+ * GCS read URL.
+ */
+interface ArchiveUrlService {
+    @GET
+    suspend fun getSignedUrl(
+        @Url url: String,
+        @Header("Authorization") bearer: String,
+        @Query("itemId") itemId: String,
+        @Query("archiveKey") archiveKey: String,
+    ): SignedUrlResponse
+}

--- a/android/app/src/main/java/com/jayteealao/trails/network/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/network/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
 import com.google.gson.GsonBuilder
 import com.jayteealao.trails.data.SharedPreferencesManager
+import com.jayteealao.trails.network.ArchiveUrlService
 import com.jayteealao.trails.network.pocket.PocketService
 import com.jayteealao.trails.services.postgrest.PostgrestService
 import com.jayteealao.trails.services.semanticSearch.modal.ModalService
@@ -128,6 +129,21 @@ object NetworkModule {
             .addCallAdapterFactory(ApiResponseCallAdapterFactory.create())
             .build()
         return retrofit.create(ModalService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideArchiveUrlService(okHttpClient: OkHttpClient): ArchiveUrlService {
+        val gson = GsonBuilder().create()
+        val retrofit = Retrofit.Builder()
+            .client(okHttpClient)
+            // The signed-URL call uses @Url to supply the absolute endpoint per
+            // call (driven by Remote Config), so this base is only the nominal
+            // value Retrofit requires — it is never used to build the request.
+            .baseUrl("https://us-central1-trails-e428e.cloudfunctions.net/")
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+        return retrofit.create(ArchiveUrlService::class.java)
     }
 
     @Provides

--- a/android/app/src/main/java/com/jayteealao/trails/network/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/network/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
 import com.google.gson.GsonBuilder
 import com.jayteealao.trails.data.SharedPreferencesManager
+import com.jayteealao.trails.di.DEFAULT_DASHBOARD_API_URL
 import com.jayteealao.trails.network.ArchiveUrlService
 import com.jayteealao.trails.network.pocket.PocketService
 import com.jayteealao.trails.services.postgrest.PostgrestService
@@ -81,7 +82,6 @@ object NetworkModule {
             .followSslRedirects(true)
             .connectionSpecs(listOf(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
             .connectionPool(ConnectionPool(20, 5, TimeUnit.MINUTES))
-            .hostnameVerifier(OkHttpClient().hostnameVerifier)
             .addNetworkInterceptor { chain ->
                 chain.proceed(
                     chain.request().newBuilder()
@@ -140,7 +140,8 @@ object NetworkModule {
             // The signed-URL call uses @Url to supply the absolute endpoint per
             // call (driven by Remote Config), so this base is only the nominal
             // value Retrofit requires — it is never used to build the request.
-            .baseUrl("https://us-central1-trails-e428e.cloudfunctions.net/")
+            // Derived from DEFAULT_DASHBOARD_API_URL to keep the host in one place.
+            .baseUrl(DEFAULT_DASHBOARD_API_URL.substringBeforeLast("/") + "/")
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
         return retrofit.create(ArchiveUrlService::class.java)

--- a/android/app/src/main/java/com/jayteealao/trails/network/dto/SignedUrlResponse.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/network/dto/SignedUrlResponse.kt
@@ -1,0 +1,19 @@
+package com.jayteealao.trails.network.dto
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Response from the `GET /app/signed-url` Cloud Function endpoint.
+ *
+ * Only [url] is consumed by the client (the short-lived V4 signed GCS read
+ * URL). The remaining fields mirror the handler response shape for parity /
+ * debugging and are optional so a shape change never breaks parsing of [url].
+ */
+data class SignedUrlResponse(
+    @SerializedName("url") val url: String,
+    @SerializedName("expires_at") val expiresAt: String? = null,
+    @SerializedName("item_id") val itemId: String? = null,
+    @SerializedName("canonical_item_id") val canonicalItemId: String? = null,
+    @SerializedName("archive_key") val archiveKey: String? = null,
+    @SerializedName("archive_source_key") val archiveSourceKey: String? = null,
+)

--- a/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailScreen.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailScreen.kt
@@ -3,10 +3,7 @@
 package com.jayteealao.trails.screens.articleDetail
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.res.Configuration
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -61,15 +58,6 @@ fun ArticleDetailScreen(
     article: Article,
     viewStore: ViewStore<ArticleDetailState, ArticleDetailEvent, ArticleDetailViewModel> = rememberViewStore { hiltViewModel() }
 ) {
-    // Launcher for Google storage consent — one-time approval
-    val consentLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            viewStore.action { retryArchiveSync() }
-        }
-    }
-
     // Mark as read when screen opens (article loading handled by MainNavigation)
     LaunchedEffect(article.itemId) {
         viewStore.action {
@@ -88,10 +76,6 @@ fun ArticleDetailScreen(
 
     viewStore.handle<ArticleDetailEvent.ShowToast> { event ->
         // Show toast message
-    }
-
-    viewStore.handle<ArticleDetailEvent.StorageConsentNeeded> { event ->
-        consentLauncher.launch(event.intent)
     }
 
     val currentArticle = viewStore.state.article ?: article

--- a/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailState.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailState.kt
@@ -1,6 +1,5 @@
 package com.jayteealao.trails.screens.articleDetail
 
-import android.content.Intent
 import com.jayteealao.trails.data.archive.ArchiveStatus
 import com.jayteealao.trails.data.archive.LocalArchive
 import com.jayteealao.trails.data.local.database.Article
@@ -28,5 +27,4 @@ sealed interface ArticleDetailEvent {
     data class ArticleMarkedAsRead(val itemId: String) : ArticleDetailEvent
     data object NavigateBack : ArticleDetailEvent
     data class ShowError(val error: Throwable) : ArticleDetailEvent
-    data class StorageConsentNeeded(val intent: Intent) : ArticleDetailEvent
 }

--- a/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailViewModel.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/screens/articleDetail/ArticleDetailViewModel.kt
@@ -2,7 +2,6 @@ package com.jayteealao.trails.screens.articleDetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.gms.auth.UserRecoverableAuthException
 import com.jayteealao.trails.common.UrlModifier
 import com.jayteealao.trails.common.di.dispatchers.Dispatcher
 import com.jayteealao.trails.common.di.dispatchers.TrailsDispatchers
@@ -211,9 +210,6 @@ class ArticleDetailViewModel @Inject constructor(
                         try {
                             archiveService.syncArchives(itemId, remoteMap)
                             Timber.d("loadArchives($itemId) — syncArchives completed")
-                        } catch (e: UserRecoverableAuthException) {
-                            Timber.w("loadArchives($itemId) — storage consent needed")
-                            e.intent?.let { _event.emit(ArticleDetailEvent.StorageConsentNeeded(it)) }
                         } catch (e: Exception) {
                             Timber.e(e, "Failed to sync archives for $itemId")
                         } finally {
@@ -283,12 +279,6 @@ class ArticleDetailViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    fun retryArchiveSync() {
-        val itemId = _article.value?.itemId ?: return
-        Timber.d("retryArchiveSync($itemId) — user granted consent, retrying")
-        loadArchives(itemId)
     }
 
     fun getAvailableArchiveTypes(): List<ArchiveType> {

--- a/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
@@ -2,8 +2,10 @@ package com.jayteealao.trails.services.firestore
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.WriteBatch
 import com.jayteealao.trails.data.local.database.Article
 import com.jayteealao.trails.network.ArticleAuthors
 import com.jayteealao.trails.network.ArticleImages
@@ -27,6 +29,7 @@ class FirestoreBackupService @Inject constructor(
     companion object {
         private const val USERS_COLLECTION = "users"
         private const val ARTICLES_COLLECTION = "articles"
+        private const val ARTICLE_MARKERS_COLLECTION = "articleMarkers"
         private const val TAGS_COLLECTION = "tags"
         private const val IMAGES_COLLECTION = "images"
         private const val VIDEOS_COLLECTION = "videos"
@@ -49,6 +52,74 @@ class FirestoreBackupService @Inject constructor(
         firestore.collection(USERS_COLLECTION)
             .document(userId)
             .collection(ARTICLES_COLLECTION)
+
+    /**
+     * Get the user's article-marker collection reference.
+     * One existence marker is written per saved article key under
+     * users/{userId}/articleMarkers/{key}; this gates the (later) tightened
+     * top-level `articles` read.
+     */
+    private fun getUserMarkersCollection(userId: String) =
+        firestore.collection(USERS_COLLECTION)
+            .document(userId)
+            .collection(ARTICLE_MARKERS_COLLECTION)
+
+    /**
+     * Marker doc keys for an article: its [Article.itemId] always, plus
+     * [Article.resolvedId] when present and distinct (the network mapper
+     * sometimes leaves it blank). Deduped so the read rule's single exists()
+     * check matches whichever key a reader passes.
+     */
+    private fun markerKeysFor(article: Article): List<String> {
+        val keys = mutableListOf(article.itemId)
+        val resolved = article.resolvedId
+        if (!resolved.isNullOrBlank() && resolved != article.itemId) {
+            keys.add(resolved)
+        }
+        return keys
+    }
+
+    /** Minimal marker body — the read rule only checks existence; the fields aid backfill idempotency and audit. */
+    private fun markerBody(key: String, source: String): Map<String, Any> =
+        mapOf(
+            "key" to key,
+            "createdAt" to FieldValue.serverTimestamp(),
+            "source" to source,
+        )
+
+    /**
+     * Queue marker writes for [article] onto an existing [batch] so they
+     * commit atomically with the article doc. Keyed by [markerKeysFor].
+     */
+    private fun addMarkerWrites(batch: WriteBatch, userId: String, article: Article) {
+        val markers = getUserMarkersCollection(userId)
+        markerKeysFor(article).forEach { key ->
+            batch.set(markers.document(key), markerBody(key, "sync"), SetOptions.merge())
+        }
+    }
+
+    /**
+     * Write a single article-existence marker for the current user. Reused by
+     * the archive read-path self-heal when a read is denied for an owned
+     * article key. Idempotent (merge); records source = "self-heal".
+     */
+    suspend fun writeArticleMarker(key: String): Result<Unit> {
+        return try {
+            val user = getCurrentUser()
+                ?: return Result.failure(Exception("User not authenticated"))
+
+            getUserMarkersCollection(user.uid)
+                .document(key)
+                .set(markerBody(key, "self-heal"), SetOptions.merge())
+                .await()
+
+            Timber.d("Wrote self-heal marker for key $key")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to write self-heal marker for key $key")
+            Result.failure(e)
+        }
+    }
 
     /**
      * Backup a single article with all its related data
@@ -126,6 +197,9 @@ class FirestoreBackupService @Inject constructor(
                     .document("metadata")
                 batch.set(metadataRef, metadata, SetOptions.merge())
             }
+
+            // Write existence marker(s) atomically with the article doc
+            addMarkerWrites(batch, user.uid, article)
 
             // Commit batch
             batch.commit().await()
@@ -515,6 +589,11 @@ class FirestoreBackupService @Inject constructor(
                     }
 
                     batch.set(articleRef, articleToSave, SetOptions.merge())
+
+                    // Write existence marker(s) alongside each article in the chunk.
+                    // Worst case per 50-article chunk: 50 article + (≤50 text) +
+                    // (≤100 marker) sets ≈ 200 ops — safely under the 500-op cap.
+                    addMarkerWrites(batch, user.uid, article)
                 }
 
                 batch.commit().await()

--- a/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
@@ -230,6 +230,10 @@ class FirestoreBackupService @Inject constructor(
                     val articleRef = getUserArticlesCollection(user.uid)
                         .document(article.itemId)
                     batch.set(articleRef, article, SetOptions.merge())
+
+                    // Write existence marker(s) atomically with the article doc so
+                    // the tightened `articles` read rule can verify ownership.
+                    addMarkerWrites(batch, user.uid, article)
                 }
 
                 batch.commit().await()

--- a/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
@@ -41,7 +41,9 @@ class FirestoreBackupService @Inject constructor(
         // users/{uid}/articles/{itemId}. Firestore allows at most 20 document-
         // access calls per batched write (same-path calls are cached, but each
         // article has a unique path). Keep chunk sizes ≤ 20.
-        private const val PAGINATION_LIMIT = 20 // ≤ 20 to respect rules budget
+        private const val WRITE_BATCH_LIMIT = 20 // ≤ 20 so each batch's marker getAfter() calls fit the Firestore rules document-access budget
+        // Read-side page size for restore operations — independent of the write-batch budget.
+        private const val RESTORE_PAGE_LIMIT = 50
     }
 
     /**
@@ -244,11 +246,11 @@ class FirestoreBackupService @Inject constructor(
 
             var successCount = 0
 
-            // Process in chunks of 20: the tightened marker create/update rule
+            // Process in chunks of WRITE_BATCH_LIMIT: the tightened marker create/update rule
             // calls getAfter on users/{uid}/articles/{itemId} per article.
             // Firestore batched writes allow at most 20 document-access calls;
             // each article contributes one unique path, so chunks must be ≤ 20.
-            articles.chunked(20).forEach { chunk ->
+            articles.chunked(WRITE_BATCH_LIMIT).forEach { chunk ->
                 val batch = firestore.batch()
 
                 chunk.forEach { article ->
@@ -386,11 +388,11 @@ class FirestoreBackupService @Inject constructor(
                     getUserArticlesCollection(user.uid)
                         .orderBy("timeAdded")
                         .startAfter(lastDocument)
-                        .limit(PAGINATION_LIMIT.toLong())
+                        .limit(RESTORE_PAGE_LIMIT.toLong())
                 } else {
                     getUserArticlesCollection(user.uid)
                         .orderBy("timeAdded")
-                        .limit(PAGINATION_LIMIT.toLong())
+                        .limit(RESTORE_PAGE_LIMIT.toLong())
                 }
 
                 val snapshot = query.get().await()
@@ -409,7 +411,7 @@ class FirestoreBackupService @Inject constructor(
                     onProgress(fetchedCount, totalCount)
                     Timber.d("Restored $fetchedCount / $totalCount articles")
 
-                    if (articles.size < PAGINATION_LIMIT) {
+                    if (articles.size < RESTORE_PAGE_LIMIT) {
                         hasMore = false
                     }
                 }
@@ -598,8 +600,8 @@ class FirestoreBackupService @Inject constructor(
 
             Timber.d("Starting paginated backup of $totalCount articles")
 
-            // Process in chunks of 50 for better performance
-            articles.chunked(PAGINATION_LIMIT).forEachIndexed { chunkIndex, chunk ->
+            // Process in chunks of WRITE_BATCH_LIMIT to respect the Firestore rules document-access budget
+            articles.chunked(WRITE_BATCH_LIMIT).forEachIndexed { chunkIndex, chunk ->
                 val batch = firestore.batch()
 
                 chunk.forEach { article ->
@@ -620,7 +622,7 @@ class FirestoreBackupService @Inject constructor(
                     batch.set(articleRef, articleToSave, SetOptions.merge())
 
                     // Write existence marker(s) alongside each article in the chunk.
-                    // Chunk size ≤ 20 (PAGINATION_LIMIT) keeps the rules budget:
+                    // Chunk size ≤ 20 (WRITE_BATCH_LIMIT) keeps the rules budget:
                     // one getAfter per article = at most 20 document-access calls.
                     addMarkerWrites(batch, user.uid, article)
                 }

--- a/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
@@ -37,7 +37,11 @@ class FirestoreBackupService @Inject constructor(
         private const val DOMAIN_METADATA_COLLECTION = "domain_metadata"
         private const val ARTICLE_TEXT_COLLECTION = "text"
         private const val MAX_TEXT_SIZE = 900_000 // 900KB to leave buffer for other fields
-        private const val PAGINATION_LIMIT = 50 // Fetch 50 articles at a time
+        // Rules budget: each article in a batch costs one getAfter call on
+        // users/{uid}/articles/{itemId}. Firestore allows at most 20 document-
+        // access calls per batched write (same-path calls are cached, but each
+        // article has a unique path). Keep chunk sizes ≤ 20.
+        private const val PAGINATION_LIMIT = 20 // ≤ 20 to respect rules budget
     }
 
     /**
@@ -79,10 +83,18 @@ class FirestoreBackupService @Inject constructor(
         return keys
     }
 
-    /** Minimal marker body — the read rule only checks existence; the fields aid backfill idempotency and audit. */
-    private fun markerBody(key: String, source: String): Map<String, Any> =
+    /**
+     * Minimal marker body. `itemId` is the doc id of the user's own article at
+     * users/{userId}/articles/{itemId} — required by the tightened create/update
+     * rule to prove the caller owns the referenced article. Both the itemId-keyed
+     * and the resolvedId-keyed marker for the same article carry the same
+     * [articleItemId] so the rules path cache only needs one getAfter call per
+     * article.
+     */
+    private fun markerBody(key: String, source: String, articleItemId: String): Map<String, Any> =
         mapOf(
             "key" to key,
+            "itemId" to articleItemId,
             "createdAt" to FieldValue.serverTimestamp(),
             "source" to source,
         )
@@ -90,11 +102,14 @@ class FirestoreBackupService @Inject constructor(
     /**
      * Queue marker writes for [article] onto an existing [batch] so they
      * commit atomically with the article doc. Keyed by [markerKeysFor].
+     * Both the itemId-keyed and resolvedId-keyed markers carry itemId =
+     * article.itemId so the rules' getAfter check resolves to the same
+     * article doc path (cached — only one access call per article).
      */
     private fun addMarkerWrites(batch: WriteBatch, userId: String, article: Article) {
         val markers = getUserMarkersCollection(userId)
         markerKeysFor(article).forEach { key ->
-            batch.set(markers.document(key), markerBody(key, "sync"), SetOptions.merge())
+            batch.set(markers.document(key), markerBody(key, "sync", article.itemId), SetOptions.merge())
         }
     }
 
@@ -102,18 +117,25 @@ class FirestoreBackupService @Inject constructor(
      * Write a single article-existence marker for the current user. Reused by
      * the archive read-path self-heal when a read is denied for an owned
      * article key. Idempotent (merge); records source = "self-heal".
+     *
+     * [key] is the marker doc id (itemId or resolvedId). [itemId] is the doc
+     * id of the user's own article at users/{uid}/articles/{itemId}; it must
+     * match an existing article doc so the tightened create/update rule's
+     * getAfter check passes. When the self-heal is triggered for an itemId-keyed
+     * read (the common case) [key] and [itemId] are the same value; pass them
+     * separately when healing a resolvedId-keyed marker.
      */
-    suspend fun writeArticleMarker(key: String): Result<Unit> {
+    suspend fun writeArticleMarker(key: String, itemId: String = key): Result<Unit> {
         return try {
             val user = getCurrentUser()
                 ?: return Result.failure(Exception("User not authenticated"))
 
             getUserMarkersCollection(user.uid)
                 .document(key)
-                .set(markerBody(key, "self-heal"), SetOptions.merge())
+                .set(markerBody(key, "self-heal", itemId), SetOptions.merge())
                 .await()
 
-            Timber.d("Wrote self-heal marker for key $key")
+            Timber.d("Wrote self-heal marker for key $key (itemId=$itemId)")
             Result.success(Unit)
         } catch (e: Exception) {
             Timber.e(e, "Failed to write self-heal marker for key $key")
@@ -222,9 +244,11 @@ class FirestoreBackupService @Inject constructor(
 
             var successCount = 0
 
-            // Process in chunks of 166: each article can produce up to 3 batch ops
-            // (article set + up to 2 marker sets), so 166 × 3 = 498 ≤ 500-op limit.
-            articles.chunked(166).forEach { chunk ->
+            // Process in chunks of 20: the tightened marker create/update rule
+            // calls getAfter on users/{uid}/articles/{itemId} per article.
+            // Firestore batched writes allow at most 20 document-access calls;
+            // each article contributes one unique path, so chunks must be ≤ 20.
+            articles.chunked(20).forEach { chunk ->
                 val batch = firestore.batch()
 
                 chunk.forEach { article ->
@@ -596,8 +620,8 @@ class FirestoreBackupService @Inject constructor(
                     batch.set(articleRef, articleToSave, SetOptions.merge())
 
                     // Write existence marker(s) alongside each article in the chunk.
-                    // Worst case per 50-article chunk: 50 article + (≤50 text) +
-                    // (≤100 marker) sets ≈ 200 ops — safely under the 500-op cap.
+                    // Chunk size ≤ 20 (PAGINATION_LIMIT) keeps the rules budget:
+                    // one getAfter per article = at most 20 document-access calls.
                     addMarkerWrites(batch, user.uid, article)
                 }
 

--- a/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
+++ b/android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt
@@ -222,8 +222,9 @@ class FirestoreBackupService @Inject constructor(
 
             var successCount = 0
 
-            // Process in chunks of 500 (Firestore batch limit)
-            articles.chunked(500).forEach { chunk ->
+            // Process in chunks of 166: each article can produce up to 3 batch ops
+            // (article set + up to 2 marker sets), so 166 × 3 = 498 ≤ 500-op limit.
+            articles.chunked(166).forEach { chunk ->
                 val batch = firestore.batch()
 
                 chunk.forEach { article ->

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
@@ -1,0 +1,161 @@
+package com.jayteealao.trails.data.archive
+
+import android.app.Application
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.jayteealao.trails.di.ARCHIVE_SIGNED_URL_BASE_KEY
+import com.jayteealao.trails.network.ArchiveUrlService
+import com.jayteealao.trails.services.firestore.FirestoreBackupService
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * Verifies the scoped signed-URL fetch path:
+ *   (a) the signed-URL request hits the `/app/signed-url` endpoint (never the
+ *       public GCS JSON API at storage.googleapis.com),
+ *   (b) it carries `Authorization: Bearer <Firebase ID token>`,
+ *   (c) the subsequent object GET (the signed URL) carries NO Authorization
+ *       header (the signed URL is self-authorizing), and
+ *   (d) the object bytes flow back through.
+ *
+ * A short-circuiting OkHttp interceptor records both requests and returns
+ * canned responses, so the test is fully deterministic with no real sockets.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArchiveServiceFetchTest {
+
+    @MockK private lateinit var firestore: FirebaseFirestore
+    @MockK private lateinit var auth: FirebaseAuth
+    @MockK(relaxed = true) private lateinit var backupService: FirestoreBackupService
+    @MockK private lateinit var remoteConfig: FirebaseRemoteConfig
+    @MockK(relaxed = true) private lateinit var localArchiveDao: LocalArchiveDao
+    @MockK(relaxed = true) private lateinit var articleDao: ArticleDao
+    @MockK(relaxed = true) private lateinit var application: Application
+
+    private val recorded = mutableListOf<Request>()
+    private lateinit var service: ArchiveService
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        // Signed-in user → cached Firebase ID token.
+        val user = mockk<FirebaseUser>()
+        every { auth.currentUser } returns user
+        val tokenResult = mockk<GetTokenResult>()
+        every { tokenResult.token } returns "idtoken"
+        every { user.getIdToken(false) } returns Tasks.forResult(tokenResult)
+
+        every { remoteConfig.getString(ARCHIVE_SIGNED_URL_BASE_KEY) } returns "https://api.example"
+
+        // One client for both legs (the Retrofit signed-URL call and the object
+        // GET). The interceptor records each request and answers it directly:
+        //   /app/signed-url → the signed-URL JSON pointing at the object,
+        //   anything else   → the archive bytes.
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                recorded += request
+                val isSignedUrlCall = request.url.encodedPath.endsWith("/app/signed-url")
+                val (bodyStr, contentType) = if (isSignedUrlCall) {
+                    """{"url":"https://archive.example/object"}""" to "application/json"
+                } else {
+                    "archive-bytes" to "application/octet-stream"
+                }
+                Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(bodyStr.toResponseBody(contentType.toMediaType()))
+                    .build()
+            }
+            .build()
+
+        val archiveUrlService = Retrofit.Builder()
+            .client(client)
+            .baseUrl("https://api.example/") // nominal — @Url supplies the real per-call URL
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ArchiveUrlService::class.java)
+
+        service = ArchiveService(
+            firestore = firestore,
+            auth = auth,
+            backupService = backupService,
+            okHttpClient = client,
+            archiveUrlService = archiveUrlService,
+            remoteConfig = remoteConfig,
+            localArchiveDao = localArchiveDao,
+            articleDao = articleDao,
+            application = application,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        recorded.clear()
+    }
+
+    @Test
+    fun `fetches via app signed-url with bearer then GETs the object with no auth header`() = runTest {
+        val bytes = service.downloadArchive("item1234", "readability")
+
+        // (d) bytes flow through
+        assertNotNull(bytes)
+        assertEquals("archive-bytes", String(bytes!!))
+        assertEquals(2, recorded.size)
+
+        // (a) + (b): signed-URL request hits /app/signed-url with the bearer token
+        val signedReq = recorded[0]
+        assertEquals("/app/signed-url", signedReq.url.encodedPath)
+        assertEquals("api.example", signedReq.url.host)
+        assertEquals("Bearer idtoken", signedReq.header("Authorization"))
+        assertEquals("item1234", signedReq.url.queryParameter("itemId"))
+        assertEquals("readability", signedReq.url.queryParameter("archiveKey"))
+
+        // (c): the object GET (the signed URL) carries no Authorization header
+        val objectReq = recorded[1]
+        assertEquals("https://archive.example/object", objectReq.url.toString())
+        assertNull(objectReq.header("Authorization"))
+        // never the public GCS JSON API
+        assertNotEquals("storage.googleapis.com", objectReq.url.host)
+    }
+
+    @Test
+    fun `returns null and never calls the endpoint when not signed in`() = runTest {
+        every { auth.currentUser } returns null
+
+        val bytes = service.downloadArchive("item1234", "readability")
+
+        assertNull(bytes)
+        assertEquals(0, recorded.size)
+    }
+}

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
@@ -159,4 +159,21 @@ class ArchiveServiceFetchTest {
         assertNull(bytes)
         assertEquals(0, recorded.size)
     }
+
+    @Test
+    fun `returns null and never calls the endpoint when ID token is null`() = runTest {
+        // User is non-null but getIdToken(false).await().token returns null.
+        val user = mockk<FirebaseUser>()
+        val tokenResult = mockk<GetTokenResult>()
+        every { tokenResult.token } returns null
+        every { user.getIdToken(false) } returns Tasks.forResult(tokenResult)
+        every { auth.currentUser } returns user
+
+        val bytes = service.downloadArchive("item1234", "readability")
+
+        assertNull(bytes)
+        // No HTTP requests should have been made — not to the signed-URL endpoint,
+        // not to any object URL.
+        assertEquals(0, recorded.size)
+    }
 }

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceFetchTest.kt
@@ -7,6 +7,7 @@ import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GetTokenResult
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.jayteealao.trails.data.local.database.ArticleDao
 import com.jayteealao.trails.di.ARCHIVE_SIGNED_URL_BASE_KEY
 import com.jayteealao.trails.network.ArchiveUrlService
 import com.jayteealao.trails.services.firestore.FirestoreBackupService

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
@@ -117,4 +117,34 @@ class ArchiveServiceTest {
         coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
         verify(exactly = 2) { docRef.get() }
     }
+
+    /**
+     * TST-03 — ownership scoping: the self-heal writes the marker keyed by the
+     * article's own itemId (not any other id), and the call is delegated entirely
+     * to backupService (which routes under users/{uid}/articleMarkers/{key}).
+     * A second article's self-heal must NOT write a marker for the first article's
+     * key, confirming per-item isolation.
+     */
+    @Test
+    fun `self-heal marker is written only for the denied item, not for other items`() = runTest {
+        // Set up a second document reference for "item2".
+        val articlesCollection = mockk<CollectionReference>()
+        val docRef2 = mockk<DocumentReference>()
+        every { firestore.collection("articles") } returns articlesCollection
+        every { articlesCollection.document("item1") } returns docRef
+        every { articlesCollection.document("item2") } returns docRef2
+
+        val snapshot = mockk<DocumentSnapshot>()
+        every { snapshot.exists() } returns false
+        // item1: denied then succeeds; item2: immediately succeeds (no denial).
+        every { docRef.get() } returnsMany listOf(Tasks.forException(denied), Tasks.forResult(snapshot))
+        every { docRef2.get() } returns Tasks.forResult(snapshot)
+
+        service.fetchWargMetadata("item1")
+        service.fetchWargMetadata("item2")
+
+        // Self-heal must have been invoked exactly once, and only for item1.
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
+        coVerify(exactly = 0) { backupService.writeArticleMarker("item2") }
+    }
 }

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
@@ -1,0 +1,114 @@
+package com.jayteealao.trails.data.archive
+
+import android.app.Application
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.jayteealao.trails.data.local.database.ArticleDao
+import com.jayteealao.trails.services.firestore.FirestoreBackupService
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Verifies the read-path self-heal: a PERMISSION_DENIED on the top-level
+ * articles/{itemId} read triggers a one-shot marker write + retry, retries at
+ * most once, and never lets the exception escape (the archive UI must not crash).
+ *
+ * Exercised via the public fetchWargMetadata(), which routes its read through
+ * the private getArticleDocWithSelfHeal() helper.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArchiveServiceTest {
+
+    @MockK private lateinit var firestore: FirebaseFirestore
+    @MockK private lateinit var auth: FirebaseAuth
+    @MockK private lateinit var backupService: FirestoreBackupService
+    @MockK(relaxed = true) private lateinit var okHttpClient: OkHttpClient
+    @MockK(relaxed = true) private lateinit var localArchiveDao: LocalArchiveDao
+    @MockK(relaxed = true) private lateinit var articleDao: ArticleDao
+    @MockK(relaxed = true) private lateinit var application: Application
+
+    private lateinit var docRef: DocumentReference
+    private lateinit var service: ArchiveService
+
+    private val denied = FirebaseFirestoreException(
+        "permission denied",
+        FirebaseFirestoreException.Code.PERMISSION_DENIED,
+    )
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        val user = mockk<FirebaseUser>()
+        every { user.uid } returns "u1"
+        every { auth.currentUser } returns user
+
+        val articlesCollection = mockk<CollectionReference>()
+        docRef = mockk()
+        every { firestore.collection("articles") } returns articlesCollection
+        every { articlesCollection.document("item1") } returns docRef
+
+        coEvery { backupService.writeArticleMarker(any()) } returns Result.success(Unit)
+
+        service = ArchiveService(
+            firestore = firestore,
+            auth = auth,
+            backupService = backupService,
+            okHttpClient = okHttpClient,
+            localArchiveDao = localArchiveDao,
+            articleDao = articleDao,
+            application = application,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `self-heals once on PERMISSION_DENIED then retries the read`() = runTest {
+        val snapshot = mockk<DocumentSnapshot>()
+        every { snapshot.exists() } returns false
+        every { docRef.get() } returnsMany listOf(Tasks.forException(denied), Tasks.forResult(snapshot))
+
+        val result = service.fetchWargMetadata("item1")
+
+        // Doc absent after the retry → graceful null, no exception escapes.
+        assertNull(result)
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
+        verify(exactly = 2) { docRef.get() }
+    }
+
+    @Test
+    fun `retries at most once and never crashes on repeated denial`() = runTest {
+        every { docRef.get() } returns Tasks.forException(denied)
+
+        val result = service.fetchWargMetadata("item1")
+
+        assertNull(result)
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
+        verify(exactly = 2) { docRef.get() }
+    }
+}

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
@@ -9,7 +9,9 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.jayteealao.trails.data.local.database.ArticleDao
+import com.jayteealao.trails.network.ArchiveUrlService
 import com.jayteealao.trails.services.firestore.FirestoreBackupService
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -43,6 +45,8 @@ class ArchiveServiceTest {
     @MockK private lateinit var auth: FirebaseAuth
     @MockK private lateinit var backupService: FirestoreBackupService
     @MockK(relaxed = true) private lateinit var okHttpClient: OkHttpClient
+    @MockK(relaxed = true) private lateinit var archiveUrlService: ArchiveUrlService
+    @MockK(relaxed = true) private lateinit var remoteConfig: FirebaseRemoteConfig
     @MockK(relaxed = true) private lateinit var localArchiveDao: LocalArchiveDao
     @MockK(relaxed = true) private lateinit var articleDao: ArticleDao
     @MockK(relaxed = true) private lateinit var application: Application
@@ -75,6 +79,8 @@ class ArchiveServiceTest {
             auth = auth,
             backupService = backupService,
             okHttpClient = okHttpClient,
+            archiveUrlService = archiveUrlService,
+            remoteConfig = remoteConfig,
             localArchiveDao = localArchiveDao,
             articleDao = articleDao,
             application = application,

--- a/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/data/archive/ArchiveServiceTest.kt
@@ -72,7 +72,10 @@ class ArchiveServiceTest {
         every { firestore.collection("articles") } returns articlesCollection
         every { articlesCollection.document("item1") } returns docRef
 
-        coEvery { backupService.writeArticleMarker(any()) } returns Result.success(Unit)
+        // Service now always calls writeArticleMarker(key, itemId) with both args explicit;
+        // stub the two-arg form so the relaxed default (null) on articleDao causes owningItemId
+        // to fall back to key, making key == itemId for standard itemId-keyed tests.
+        coEvery { backupService.writeArticleMarker(any(), any()) } returns Result.success(Unit)
 
         service = ArchiveService(
             firestore = firestore,
@@ -102,8 +105,10 @@ class ArchiveServiceTest {
         val result = service.fetchWargMetadata("item1")
 
         // Doc absent after the retry → graceful null, no exception escapes.
+        // articleDao is relaxed so owningItemId("item1") falls back to "item1";
+        // both key and itemId are "item1" for standard itemId-keyed articles.
         assertNull(result)
-        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1", "item1") }
         verify(exactly = 2) { docRef.get() }
     }
 
@@ -114,7 +119,7 @@ class ArchiveServiceTest {
         val result = service.fetchWargMetadata("item1")
 
         assertNull(result)
-        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1", "item1") }
         verify(exactly = 2) { docRef.get() }
     }
 
@@ -144,7 +149,8 @@ class ArchiveServiceTest {
         service.fetchWargMetadata("item2")
 
         // Self-heal must have been invoked exactly once, and only for item1.
-        coVerify(exactly = 1) { backupService.writeArticleMarker("item1") }
-        coVerify(exactly = 0) { backupService.writeArticleMarker("item2") }
+        // owningItemId falls back to the key for both items (relaxed articleDao → null).
+        coVerify(exactly = 1) { backupService.writeArticleMarker("item1", "item1") }
+        coVerify(exactly = 0) { backupService.writeArticleMarker("item2", any()) }
     }
 }

--- a/android/app/src/test/java/com/jayteealao/trails/screens/articleList/ArticleListViewModelTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/screens/articleList/ArticleListViewModelTest.kt
@@ -14,9 +14,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkConstructor
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -71,7 +72,7 @@ class ArticleListViewModelTest {
     @After
     fun tearDown() {
         clearAllMocks()
-        runCatching { unmockkConstructor(Unfurler::class) }
+        runCatching { unmockkStatic("me.saket.unfurl.UnfurlerKt") }
         Dispatchers.resetMain()
     }
 
@@ -80,8 +81,15 @@ class ArticleListViewModelTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         Dispatchers.setMain(dispatcher)
 
-        mockkConstructor(Unfurler::class)
-        coEvery { anyConstructed<Unfurler>().unfurl(any()) } throws RuntimeException("unfurl failure")
+        // Unfurler is an interface built via the top-level Unfurler() factory, so it
+        // can't be mocked with mockkConstructor. Mock the factory so the ViewModel's
+        // `val unfurler = Unfurler()` receives a mock whose suspend unfurl() fails —
+        // this is the metadata-fetch-failure path under test.
+        val unfurler = mockk<Unfurler>()
+        coEvery { unfurler.unfurl(any<String>()) } throws RuntimeException("unfurl failure")
+        mockkStatic("me.saket.unfurl.UnfurlerKt")
+        every { Unfurler() } returns unfurler
+
         val upsertSlot = slot<Article>()
         coEvery { articleDao.upsertNewArticle(capture(upsertSlot)) } answers { upsertSlot.captured.itemId }
 
@@ -113,7 +121,11 @@ class ArticleListViewModelTest {
         )
 
         val sharedUrl = "https://example.com/article"
-        viewModel.saveUrl(Uri.parse(sharedUrl), "Shared title")
+        // android.net.Uri has no JVM implementation; saveUrl() only reads
+        // givenUrl.toString(), so a mock that echoes the URL is sufficient.
+        val sharedUri = mockk<Uri>()
+        every { sharedUri.toString() } returns sharedUrl
+        viewModel.saveUrl(sharedUri, "Shared title")
         advanceUntilIdle()
 
         assertEquals(sharedUrl, upsertSlot.captured.url)

--- a/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
@@ -17,6 +17,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -129,5 +130,61 @@ class FirestoreBackupServiceTest {
         assertTrue(result.isSuccess)
         verify(exactly = 1) { markersCollection.document(any()) }
         verify(exactly = 1) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+    }
+
+    /**
+     * TST-04 — writeArticleMarker happy path: the marker doc is written under
+     * users/{uid}/articleMarkers/{key} (owner's uid path) with source = "self-heal".
+     */
+    @Test
+    fun `writeArticleMarker writes marker under owner uid path with self-heal source`() = runTest {
+        val markerDoc = mockk<DocumentReference>()
+        every { markersCollection.document("key1") } returns markerDoc
+        every { markerDoc.set(any(), any()) } returns Tasks.forResult(null)
+
+        val result = service.writeArticleMarker("key1")
+
+        assertTrue(result.isSuccess)
+        // Must set on the doc under users/u1/articleMarkers/key1.
+        verify(exactly = 1) {
+            markerDoc.set(
+                match<Map<String, Any>> { it["key"] == "key1" && it["source"] == "self-heal" },
+                any(),
+            )
+        }
+    }
+
+    /**
+     * TST-04 — writeArticleMarker failure path: when Firestore throws, the
+     * function returns a failed Result instead of propagating the exception.
+     */
+    @Test
+    fun `writeArticleMarker returns failure result when Firestore set throws`() = runTest {
+        val markerDoc = mockk<DocumentReference>()
+        every { markersCollection.document("key1") } returns markerDoc
+        every { markerDoc.set(any(), any()) } returns Tasks.forException(RuntimeException("network error"))
+
+        val result = service.writeArticleMarker("key1")
+
+        assertFalse(result.isSuccess)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `backupArticles bulk path writes sync markers for every article`() = runTest {
+        val markerDoc1 = mockk<DocumentReference>()
+        val markerDoc2 = mockk<DocumentReference>()
+        every { markersCollection.document("a1") } returns markerDoc1
+        every { markersCollection.document("a2") } returns markerDoc2
+
+        val result = service.backupArticles(listOf(article("a1", null), article("a2", null)))
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) {
+            batch.set(markerDoc1, match<Map<String, Any>> { it["key"] == "a1" && it["source"] == "sync" }, any())
+        }
+        verify(exactly = 1) {
+            batch.set(markerDoc2, match<Map<String, Any>> { it["key"] == "a2" && it["source"] == "sync" }, any())
+        }
     }
 }

--- a/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
@@ -1,0 +1,133 @@
+package com.jayteealao.trails.services.firestore
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.WriteBatch
+import com.jayteealao.trails.data.local.database.Article
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Verifies that backing up an article also writes its existence marker(s)
+ * onto the same WriteBatch (so they commit atomically), keyed by itemId plus
+ * resolvedId when distinct.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FirestoreBackupServiceTest {
+
+    @MockK private lateinit var firestore: FirebaseFirestore
+    @MockK private lateinit var auth: FirebaseAuth
+    @MockK(relaxed = true) private lateinit var batch: WriteBatch
+
+    private lateinit var markersCollection: CollectionReference
+    private lateinit var service: FirestoreBackupService
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        val user = mockk<FirebaseUser>()
+        every { user.uid } returns "u1"
+        every { auth.currentUser } returns user
+
+        val usersCollection = mockk<CollectionReference>()
+        val userDoc = mockk<DocumentReference>()
+        markersCollection = mockk()
+        val articlesCollection = mockk<CollectionReference>()
+        val articleDoc = mockk<DocumentReference>(relaxed = true)
+
+        every { firestore.collection("users") } returns usersCollection
+        every { usersCollection.document("u1") } returns userDoc
+        every { userDoc.collection("articleMarkers") } returns markersCollection
+        every { userDoc.collection("articles") } returns articlesCollection
+        every { articlesCollection.document(any()) } returns articleDoc
+
+        every { firestore.batch() } returns batch
+        every { batch.commit() } returns Tasks.forResult(null)
+
+        service = FirestoreBackupService(firestore, auth)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun article(id: String, resolved: String?): Article {
+        val a = mockk<Article>(relaxed = true)
+        every { a.itemId } returns id
+        every { a.resolvedId } returns resolved
+        every { a.text } returns null
+        return a
+    }
+
+    @Test
+    fun `writes a single sync marker for itemId when resolvedId is null`() = runTest {
+        val markerDoc = mockk<DocumentReference>()
+        every { markersCollection.document("item1") } returns markerDoc
+
+        val result = service.backupArticle(article("item1", null))
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) {
+            batch.set(
+                markerDoc,
+                match<Map<String, Any>> { it["key"] == "item1" && it["source"] == "sync" },
+                any(),
+            )
+        }
+        // Only one marker doc requested → no spurious resolvedId marker.
+        verify(exactly = 1) { markersCollection.document(any()) }
+    }
+
+    @Test
+    fun `writes markers for both itemId and a distinct resolvedId`() = runTest {
+        val itemMarker = mockk<DocumentReference>()
+        val resolvedMarker = mockk<DocumentReference>()
+        every { markersCollection.document("item1") } returns itemMarker
+        every { markersCollection.document("resolved1") } returns resolvedMarker
+
+        val result = service.backupArticle(article("item1", "resolved1"))
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) { batch.set(itemMarker, match<Map<String, Any>> { it["key"] == "item1" }, any()) }
+        verify(exactly = 1) { batch.set(resolvedMarker, match<Map<String, Any>> { it["key"] == "resolved1" }, any()) }
+        verify(exactly = 2) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+    }
+
+    @Test
+    fun `does not duplicate the marker when resolvedId equals itemId`() = runTest {
+        every { markersCollection.document("item1") } returns mockk<DocumentReference>()
+
+        val result = service.backupArticle(article("item1", "item1"))
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) { markersCollection.document(any()) }
+        verify(exactly = 1) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+    }
+
+    @Test
+    fun `does not write a resolvedId marker when resolvedId is blank`() = runTest {
+        every { markersCollection.document("item1") } returns mockk<DocumentReference>()
+
+        val result = service.backupArticle(article("item1", "  "))
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) { markersCollection.document(any()) }
+        verify(exactly = 1) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+    }
+}

--- a/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
+++ b/android/app/src/test/java/com/jayteealao/trails/services/firestore/FirestoreBackupServiceTest.kt
@@ -87,7 +87,9 @@ class FirestoreBackupServiceTest {
         verify(exactly = 1) {
             batch.set(
                 markerDoc,
-                match<Map<String, Any>> { it["key"] == "item1" && it["source"] == "sync" },
+                match<Map<String, Any>> {
+                    it["key"] == "item1" && it["source"] == "sync" && it["itemId"] == "item1"
+                },
                 any(),
             )
         }
@@ -105,8 +107,21 @@ class FirestoreBackupServiceTest {
         val result = service.backupArticle(article("item1", "resolved1"))
 
         assertTrue(result.isSuccess)
-        verify(exactly = 1) { batch.set(itemMarker, match<Map<String, Any>> { it["key"] == "item1" }, any()) }
-        verify(exactly = 1) { batch.set(resolvedMarker, match<Map<String, Any>> { it["key"] == "resolved1" }, any()) }
+        // Both markers carry itemId = "item1" (the owning article's id).
+        verify(exactly = 1) {
+            batch.set(
+                itemMarker,
+                match<Map<String, Any>> { it["key"] == "item1" && it["itemId"] == "item1" },
+                any(),
+            )
+        }
+        verify(exactly = 1) {
+            batch.set(
+                resolvedMarker,
+                match<Map<String, Any>> { it["key"] == "resolved1" && it["itemId"] == "item1" },
+                any(),
+            )
+        }
         verify(exactly = 2) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
     }
 
@@ -118,7 +133,13 @@ class FirestoreBackupServiceTest {
 
         assertTrue(result.isSuccess)
         verify(exactly = 1) { markersCollection.document(any()) }
-        verify(exactly = 1) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+        verify(exactly = 1) {
+            batch.set(
+                any(),
+                match<Map<String, Any>> { it["source"] == "sync" && it["itemId"] == "item1" },
+                any(),
+            )
+        }
     }
 
     @Test
@@ -129,12 +150,19 @@ class FirestoreBackupServiceTest {
 
         assertTrue(result.isSuccess)
         verify(exactly = 1) { markersCollection.document(any()) }
-        verify(exactly = 1) { batch.set(any(), match<Map<String, Any>> { it["source"] == "sync" }, any()) }
+        verify(exactly = 1) {
+            batch.set(
+                any(),
+                match<Map<String, Any>> { it["source"] == "sync" && it["itemId"] == "item1" },
+                any(),
+            )
+        }
     }
 
     /**
      * TST-04 — writeArticleMarker happy path: the marker doc is written under
-     * users/{uid}/articleMarkers/{key} (owner's uid path) with source = "self-heal".
+     * users/{uid}/articleMarkers/{key} (owner's uid path) with source = "self-heal"
+     * and itemId = key (default: key and itemId are the same for itemId-keyed markers).
      */
     @Test
     fun `writeArticleMarker writes marker under owner uid path with self-heal source`() = runTest {
@@ -145,10 +173,35 @@ class FirestoreBackupServiceTest {
         val result = service.writeArticleMarker("key1")
 
         assertTrue(result.isSuccess)
-        // Must set on the doc under users/u1/articleMarkers/key1.
+        // Must set on the doc under users/u1/articleMarkers/key1 with itemId = key1.
         verify(exactly = 1) {
             markerDoc.set(
-                match<Map<String, Any>> { it["key"] == "key1" && it["source"] == "self-heal" },
+                match<Map<String, Any>> {
+                    it["key"] == "key1" && it["source"] == "self-heal" && it["itemId"] == "key1"
+                },
+                any(),
+            )
+        }
+    }
+
+    /**
+     * writeArticleMarker with explicit itemId: for a resolvedId-keyed self-heal
+     * the caller can pass the owning article's itemId separately.
+     */
+    @Test
+    fun `writeArticleMarker with explicit itemId carries correct itemId in marker body`() = runTest {
+        val markerDoc = mockk<DocumentReference>()
+        every { markersCollection.document("resolved-key") } returns markerDoc
+        every { markerDoc.set(any(), any()) } returns Tasks.forResult(null)
+
+        val result = service.writeArticleMarker("resolved-key", itemId = "article-1")
+
+        assertTrue(result.isSuccess)
+        verify(exactly = 1) {
+            markerDoc.set(
+                match<Map<String, Any>> {
+                    it["key"] == "resolved-key" && it["itemId"] == "article-1" && it["source"] == "self-heal"
+                },
                 any(),
             )
         }
@@ -181,10 +234,18 @@ class FirestoreBackupServiceTest {
 
         assertTrue(result.isSuccess)
         verify(exactly = 1) {
-            batch.set(markerDoc1, match<Map<String, Any>> { it["key"] == "a1" && it["source"] == "sync" }, any())
+            batch.set(
+                markerDoc1,
+                match<Map<String, Any>> { it["key"] == "a1" && it["source"] == "sync" && it["itemId"] == "a1" },
+                any(),
+            )
         }
         verify(exactly = 1) {
-            batch.set(markerDoc2, match<Map<String, Any>> { it["key"] == "a2" && it["source"] == "sync" }, any())
+            batch.set(
+                markerDoc2,
+                match<Map<String, Any>> { it["key"] == "a2" && it["source"] == "sync" && it["itemId"] == "a2" },
+                any(),
+            )
         }
     }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -177,6 +177,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-ai = { module = "com.google.firebase:firebase-ai" }
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore" }
+firebase-config = { module = "com.google.firebase:firebase-config" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 google-signin = { group = "com.google.android.gms", name = "play-services-auth", version = "21.0.0" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -16,6 +16,7 @@ Project ID: `trails-e428e` (also referenced from `warg/scripts/deploy.sh`).
 | `firebase.json` | Hosting/Firestore/Storage config |
 | `firestore.rules` | Security rules for the Firestore documents Trails reads and Warg writes |
 | `storage.rules` | Security rules for the GCS bucket Warg uses for archive artifacts |
+| `test/` | Standalone `@firebase/rules-unit-testing` suite run against the Firestore emulator; gates deploy in CI (`firebase-rules.yml`). `cd test && npm install && npm test`. |
 
 ## Deploying
 
@@ -24,6 +25,19 @@ From this directory:
 ```bash
 firebase deploy --only firestore:rules,storage
 ```
+
+## Article markers & sequenced read tightening
+
+The top-level `articles` read rule is intentionally still `isAuthenticated()`.
+Tightening it to a marker-gated, get-only read is a **later, separately
+deployed** change: it can only land once every saved article has a per-user
+existence marker at `users/{uid}/articleMarkers/{key}` (see
+[`../shared-types/MarkerSchema.md`](../shared-types/MarkerSchema.md)).
+
+Markers are written by the Android client on every sync/backup and on
+read-denial self-heal; historical articles are covered by a one-off backfill.
+Because rules auto-deploy on push to `main`, the read-tightening commit must be
+the **last** to merge so reads keep working until coverage is in place.
 
 ## Why this is here, not under android/ or warg/
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -39,6 +39,67 @@ read-denial self-heal; historical articles are covered by a one-off backfill.
 Because rules auto-deploy on push to `main`, the read-tightening commit must be
 the **last** to merge so reads keep working until coverage is in place.
 
+## Archive content reads (GCS bucket lockdown)
+
+Archive **content** (the rendered / readability / markdown / singlefile /
+monolith / screenshot artifacts in `gs://htbase-archives-standard`, GCP project
+`trails-414917`) now loads via a per-user signed-URL endpoint instead of a
+public bucket binding:
+
+- The app calls `GET /app/signed-url?itemId=…&archiveKey=…` on the `dashboardApi`
+  Cloud Function with an `Authorization: Bearer <Firebase ID token>` header.
+- The endpoint verifies the token (anonymous sign-ins rejected), confirms the
+  caller owns `users/{uid}/articles/{itemId}`, and returns a short-lived
+  (15-minute) V4 signed read URL. The app then GETs the object directly — no
+  Google-account / GCS OAuth scope is involved anymore.
+- The bucket no longer grants `allAuthenticatedUsers → roles/storage.objectViewer`,
+  and Public Access Prevention (PAP) is enforced.
+
+The dashboard's existing `GET /signed-url` route (internal API key) is unchanged;
+both routes share one signing implementation and differ only in how the owner is
+identified (hardcoded dashboard user vs. verified token uid).
+
+### Deploy ordering (load-bearing — the migration is fail-safe only in this order)
+
+1. Deploy the updated `dashboardApi` (adds the `/app/signed-url` route).
+2. Roll out the app build that fetches via `/app/signed-url`, and confirm an
+   archive still loads **while `allAuthenticatedUsers` is still present**.
+3. **Only then** remove the public binding and enforce PAP:
+   ```bash
+   gcloud storage buckets remove-iam-policy-binding gs://htbase-archives-standard \
+     --project=trails-414917 \
+     --member=allAuthenticatedUsers --role=roles/storage.objectViewer
+   gcloud storage buckets update gs://htbase-archives-standard \
+     --project=trails-414917 --public-access-prevention
+   ```
+4. Re-fetch an archive on the new build → it should still load. Assert the
+   binding is gone:
+   ```bash
+   gcloud storage buckets get-iam-policy gs://htbase-archives-standard --project=trails-414917
+   ```
+
+### Signing service-account preconditions
+
+The `dashboardApi` service account must hold `roles/iam.serviceAccountTokenCreator`
+on itself (project `trails-e428e`, for the `signBlob` call V4 signing uses) and
+`roles/storage.objectViewer` on the bucket (project `trails-414917`). The
+dashboard already signs URLs in production, so these are expected to be in place
+— verify read-only before removing the public binding.
+
+### Rollback
+
+If the signed-URL path regresses, re-open the bucket (disable PAP first if it
+blocks re-adding the binding):
+```bash
+gcloud storage buckets update gs://htbase-archives-standard \
+  --project=trails-414917 --no-public-access-prevention
+gcloud storage buckets add-iam-policy-binding gs://htbase-archives-standard \
+  --project=trails-414917 \
+  --member=allAuthenticatedUsers --role=roles/storage.objectViewer
+```
+Rollback is bucket-level: the old OAuth/`devstorage` client path has been removed,
+so there is no app-side toggle to revert.
+
 ## Why this is here, not under android/ or warg/
 
 The rules govern documents that both stacks touch. A change to a `WargMetadata`

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -11,5 +11,10 @@
       "rules": "storage.rules",
       "target": "archives"
     }
-  ]
+  ],
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    }
+  }
 }

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -35,8 +35,20 @@ service cloud.firestore {
 
       // Article existence markers - one doc per saved article key, used to
       // gate the (later) tightened top-level `articles` read. Owner-scoped.
+      //
+      // CREATE / UPDATE: requires proof the user owns the referenced article.
+      // The `itemId` field must point to an existing users/{userId}/articles/{itemId}
+      // doc — either written in the same batch (backup flow) or already present
+      // in Firestore (self-heal flow). `getAfter` covers both cases and is cached
+      // by path, so a batch of N articles costs N unique getAfter calls.
+      // RULES BUDGET: callers must keep batches ≤ 20 articles (N unique getAfter
+      // paths) to stay within the 20-document-access limit per batched write.
       match /articleMarkers/{markerId} {
-        allow read, write: if isOwner(userId);
+        allow read: if isOwner(userId);
+        allow delete: if isOwner(userId);
+        allow create, update: if isOwner(userId)
+          && request.resource.data.itemId is string
+          && getAfter(/databases/$(database)/documents/users/$(userId)/articles/$(request.resource.data.itemId)).data != null;
       }
 
       // Articles subcollection - user can only access their own articles

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -13,23 +13,31 @@ service cloud.firestore {
     }
 
     // Top-level articles collection (written by Warg backend, read-only for app)
+    // NOTE: read is intentionally still `isAuthenticated()` — the marker-gated
+    // get-only tightening (and `list: if false`) is a later, separately
+    // deployed change once per-user markers are written and backfilled.
     match /articles/{itemId} {
       allow read: if isAuthenticated();
       allow write: if false;  // Backend service account only
     }
 
-    // Debug logs (debug builds only, temporary)
-    match /debug_logs/{sessionId} {
-      allow read, write: if isAuthenticated();
-      match /entries/{entryId} {
-        allow read, write: if isAuthenticated();
-      }
+    // Debug logs (debug builds only, temporary) — owner-scoped per uid.
+    // Session docs live under debug_logs/{uid}/sessions/{sessionId}; the old
+    // flat debug_logs/{sessionId} layout is intentionally denied by default.
+    match /debug_logs/{userId}/sessions/{sessionId} {
+      allow read, write: if isOwner(userId);
     }
 
     // Users collection - each user can only access their own data
     match /users/{userId} {
       // Allow users to read and write their own user document
       allow read, write: if isOwner(userId);
+
+      // Article existence markers - one doc per saved article key, used to
+      // gate the (later) tightened top-level `articles` read. Owner-scoped.
+      match /articleMarkers/{markerId} {
+        allow read, write: if isOwner(userId);
+      }
 
       // Articles subcollection - user can only access their own articles
       match /articles/{articleId} {

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -2,7 +2,11 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /archives/{allPaths=**} {
-      allow read: if request.auth != null;
+      // Archive reads are owner-scoped via the per-user signed-URL Cloud Function
+      // endpoint (GET /app/signed-url). Direct Firebase Storage SDK reads are denied.
+      // Bucket: htbase-archives-standard (firebase/.firebaserc "archives" target).
+      // The Android app never uses the Firebase Storage SDK for archive reads.
+      allow read: if false;
       allow write: if false;
     }
   }

--- a/firebase/test/firestore-rules.test.ts
+++ b/firebase/test/firestore-rules.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const PROJECT_ID = 'demo-trails';
+const OWNER = 'owner-uid';
+const OTHER = 'other-uid';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(resolve(here, '..', 'firestore.rules'), 'utf8'),
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+});
+
+afterEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+const ownerDb = () => testEnv.authenticatedContext(OWNER).firestore();
+const otherDb = () => testEnv.authenticatedContext(OTHER).firestore();
+const anonDb = () => testEnv.unauthenticatedContext().firestore();
+
+describe('articleMarkers (users/{uid}/articleMarkers/{key})', () => {
+  it('owner can write then read their own marker', async () => {
+    const db = ownerDb();
+    const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
+    await assertSucceeds(setDoc(ref, { key: 'article-1', source: 'sync' }));
+    await assertSucceeds(getDoc(ref));
+  });
+
+  it('a different signed-in user cannot read or write the owner marker', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articleMarkers/article-1`), {
+        key: 'article-1',
+        source: 'sync',
+      });
+    });
+    const db = otherDb();
+    const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
+    await assertFails(getDoc(ref));
+    await assertFails(setDoc(ref, { key: 'article-1', source: 'sync' }));
+  });
+
+  it('an unauthenticated user cannot read or write a marker', async () => {
+    const db = anonDb();
+    const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
+    await assertFails(getDoc(ref));
+    await assertFails(setDoc(ref, { key: 'article-1', source: 'sync' }));
+  });
+});
+
+describe('debug_logs (debug_logs/{uid}/sessions/{sessionId})', () => {
+  it('owner can write then read their own session doc', async () => {
+    const db = ownerDb();
+    const ref = doc(db, `debug_logs/${OWNER}/sessions/sess-1_article-1`);
+    await assertSucceeds(setDoc(ref, { sessionId: 'sess-1', events: [] }));
+    await assertSucceeds(getDoc(ref));
+  });
+
+  it('a user cannot access another user session doc', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `debug_logs/${OWNER}/sessions/sess-1_article-1`),
+        { sessionId: 'sess-1', events: [] },
+      );
+    });
+    const db = otherDb();
+    const ref = doc(db, `debug_logs/${OWNER}/sessions/sess-1_article-1`);
+    await assertFails(getDoc(ref));
+    await assertFails(setDoc(ref, { sessionId: 'sess-1', events: [] }));
+  });
+
+  it('the legacy flat debug_logs/{sessionId} layout is denied by default', async () => {
+    const db = ownerDb();
+    const ref = doc(db, 'debug_logs/legacy-session');
+    await assertFails(getDoc(ref));
+    await assertFails(setDoc(ref, { sessionId: 'legacy-session' }));
+  });
+});
+
+describe('articles read rule (unchanged this slice)', () => {
+  it('an authenticated user can still read a top-level article (deploy-safety)', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), 'articles/article-1'), { title: 'hello' });
+    });
+    const db = ownerDb();
+    await assertSucceeds(getDoc(doc(db, 'articles/article-1')));
+    // The marker-gated get-only / `list: if false` tightening and its full
+    // get/list matrix are a later, separately deployed change — not asserted here.
+  });
+});

--- a/firebase/test/firestore-rules.test.ts
+++ b/firebase/test/firestore-rules.test.ts
@@ -8,7 +8,7 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, writeBatch } from 'firebase/firestore';
 import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -43,31 +43,165 @@ const otherDb = () => testEnv.authenticatedContext(OTHER).firestore();
 const anonDb = () => testEnv.unauthenticatedContext().firestore();
 
 describe('articleMarkers (users/{uid}/articleMarkers/{key})', () => {
-  it('owner can write then read their own marker', async () => {
-    const db = ownerDb();
-    const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
-    await assertSucceeds(setDoc(ref, { key: 'article-1', source: 'sync' }));
-    await assertSucceeds(getDoc(ref));
-  });
+  // ── reads ────────────────────────────────────────────────────────────────
 
-  it('a different signed-in user cannot read or write the owner marker', async () => {
+  it('owner can read their own marker (seeded via bypass)', async () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(doc(ctx.firestore(), `users/${OWNER}/articleMarkers/article-1`), {
         key: 'article-1',
+        itemId: 'article-1',
+        source: 'sync',
+      });
+    });
+    const db = ownerDb();
+    await assertSucceeds(getDoc(doc(db, `users/${OWNER}/articleMarkers/article-1`)));
+  });
+
+  // ── (a) batch write: article doc + marker in same batch → allowed ────────
+
+  it('(a) owner creating a marker WITH its owned article written in the same batch is allowed', async () => {
+    const db = ownerDb();
+    const batch = writeBatch(db);
+    // Article doc written first in the batch (mirrors FirestoreBackupService order).
+    batch.set(doc(db, `users/${OWNER}/articles/article-1`), { title: 'hello' });
+    // itemId-keyed marker in the same batch.
+    batch.set(doc(db, `users/${OWNER}/articleMarkers/article-1`), {
+      key: 'article-1',
+      itemId: 'article-1',
+      source: 'sync',
+    });
+    await assertSucceeds(batch.commit());
+  });
+
+  it('(a) batch: resolvedId-keyed marker whose data.itemId points at the article in the same batch is allowed', async () => {
+    const db = ownerDb();
+    const batch = writeBatch(db);
+    batch.set(doc(db, `users/${OWNER}/articles/article-1`), { title: 'hello' });
+    // resolvedId-keyed marker — different doc id, but same itemId value.
+    batch.set(doc(db, `users/${OWNER}/articleMarkers/resolved-1`), {
+      key: 'resolved-1',
+      itemId: 'article-1',
+      source: 'sync',
+    });
+    await assertSucceeds(batch.commit());
+  });
+
+  // ── (b) pre-existing article doc → allowed (self-heal shape) ────────────
+
+  it('(b) owner creating a marker when the article doc already exists (self-heal) is allowed', async () => {
+    // Seed the article doc bypassing rules.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articles/article-1`), {
+        title: 'hello',
+      });
+    });
+    const db = ownerDb();
+    await assertSucceeds(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/article-1`), {
+        key: 'article-1',
+        itemId: 'article-1',
+        source: 'self-heal',
+      }),
+    );
+  });
+
+  it('(b) resolvedId-keyed marker whose data.itemId points at a pre-existing article is allowed', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articles/article-1`), {
+        title: 'hello',
+      });
+    });
+    const db = ownerDb();
+    await assertSucceeds(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/resolved-1`), {
+        key: 'resolved-1',
+        itemId: 'article-1',
+        source: 'self-heal',
+      }),
+    );
+  });
+
+  // ── (c) no corresponding article doc → denied (minting attack) ──────────
+
+  it('(c) owner creating a marker with NO corresponding users/{uid}/articles doc is denied', async () => {
+    const db = ownerDb();
+    await assertFails(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/article-ghost`), {
+        key: 'article-ghost',
+        itemId: 'article-ghost',
+        source: 'sync',
+      }),
+    );
+  });
+
+  it('(c) owner creating a marker with an itemId that references a non-existent article is denied', async () => {
+    const db = ownerDb();
+    await assertFails(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/resolved-ghost`), {
+        key: 'resolved-ghost',
+        itemId: 'article-ghost', // article-ghost does not exist
+        source: 'sync',
+      }),
+    );
+  });
+
+  // ── (d) marker missing the itemId field → denied ─────────────────────────
+
+  it('(d) owner creating a marker that is missing the itemId field is denied', async () => {
+    // Seed article so only the missing-field check determines the outcome.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articles/article-1`), {
+        title: 'hello',
+      });
+    });
+    const db = ownerDb();
+    await assertFails(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/article-1`), {
+        key: 'article-1',
+        // itemId intentionally omitted
+        source: 'sync',
+      }),
+    );
+  });
+
+  // ── (e) cross-user isolation ─────────────────────────────────────────────
+
+  it('(e) a different signed-in user cannot read the owner marker', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articleMarkers/article-1`), {
+        key: 'article-1',
+        itemId: 'article-1',
         source: 'sync',
       });
     });
     const db = otherDb();
-    const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
-    await assertFails(getDoc(ref));
-    await assertFails(setDoc(ref, { key: 'article-1', source: 'sync' }));
+    await assertFails(getDoc(doc(db, `users/${OWNER}/articleMarkers/article-1`)));
   });
 
-  it('an unauthenticated user cannot read or write a marker', async () => {
+  it('(e) a different signed-in user cannot write to the owner marker path', async () => {
+    // Seed OWNER's article so the only barrier is the userId mismatch.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `users/${OWNER}/articles/article-1`), {
+        title: 'hello',
+      });
+    });
+    const db = otherDb();
+    await assertFails(
+      setDoc(doc(db, `users/${OWNER}/articleMarkers/article-1`), {
+        key: 'article-1',
+        itemId: 'article-1',
+        source: 'sync',
+      }),
+    );
+  });
+
+  it('(e) an unauthenticated user cannot read or write a marker', async () => {
     const db = anonDb();
     const ref = doc(db, `users/${OWNER}/articleMarkers/article-1`);
     await assertFails(getDoc(ref));
-    await assertFails(setDoc(ref, { key: 'article-1', source: 'sync' }));
+    await assertFails(
+      setDoc(ref, { key: 'article-1', itemId: 'article-1', source: 'sync' }),
+    );
   });
 });
 

--- a/firebase/test/package-lock.json
+++ b/firebase/test/package-lock.json
@@ -1,0 +1,10734 @@
+{
+  "name": "@trails/firestore-rules-test",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@trails/firestore-rules-test",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@firebase/rules-unit-testing": "^5.0.1",
+        "@types/node": "^22.10.0",
+        "firebase": "^12.0.0",
+        "firebase-tools": "^15.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": "22"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apphosting/common": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.8.tgz",
+      "integrity": "sha512-RJu5gXs2HYV7+anxpVPpp04oXeuHbV3qn402AdXVlnuYM/uWo7aceqmngpfp6Bi376UzRqGjfpdwFHxuwsEGXQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
+      "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.21.tgz",
+      "integrity": "sha512-kv8Z7UmmBVECHud63VblgQLp4A+qSklNP7H22VQqFQGrWFTodc73bubcjgmBqThFsIIiEeAEQQYwWGaK2lSDtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.0.tgz",
+      "integrity": "sha512-nJJDQKqjAcbkZdZGT/5WTVLrGZ+pYhWbwKC90nNzmvtoRTtnOJaNS34fhKSHQeB9SALgD2kxuWT5I4AkytdZ/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
+      "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.4.tgz",
+      "integrity": "sha512-G8EsbVJV9gSfoibx0dNoNOUrvr+PkL7J//+W/BST/oUassimkZeq9bjj3bKkB0pn4og5GMQ9qs7FefwP00kkgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.4.tgz",
+      "integrity": "sha512-9iP0MvmaVagulNXmrca96U3tqNAI3j98wsC1z7rj62nnOTajlrHM//jjB9VoHqRw6/islMskp6RsKnM7vhLDqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.4",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.13.tgz",
+      "integrity": "sha512-pn3FvXwUR34kWPccDQfCKsNZcM2wD1OS+J1jeEgzM1ZNXoxR2NaF6e5DjDuRrnTwR6LN2XQQt0IqE6yKmgpCQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.13",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.2.tgz",
+      "integrity": "sha512-B4w0iS7MxRg28oIh2fJFTE6cM0lYdBrW19eHpc42jqEcloUjlYyVrpPqZvqA4+v9KFEVSKEs2SfWyta7hbzkJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.7.tgz",
+      "integrity": "sha512-XgKnOgY1Siq7gylAmLkYtHAlRxNeWEAspH+nO3gJZJnfHqoTHbr9UjJ3nHNFALYXV5CfpQlyPROyB2ztySBHBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.2",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.15.0.tgz",
+      "integrity": "sha512-Fj9osqYkz2Rqr7kW3/A8BRd8CyJ7yA5K8YjhihRdyJWbL+FsELVcR6DpoCplrp1IyU+xeGgTubo1UOySXpY+EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.10.tgz",
+      "integrity": "sha512-yMP3FADDjikdrQv4YmvL4EkIny6Hw+N+a2O5T40rlHiniyMpRPxgYkKiFOvMZnsqKLqBVnKqCAElC0pa/IZtdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.15.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.4.tgz",
+      "integrity": "sha512-lslywR5lGvHWTu4z/MPoYs3UwS3CKdeY+ELXY87087VsOpBpkD+9Orra23tA9GW683arPTDOM3CM6eKmtiOO3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.25.tgz",
+      "integrity": "sha512-FnA5S4IxFJAAFrCnYzWlO0FCaizlYdqhe42ygFMA+wE/mUP+w36iXzHyKj1OO1A+2gyMFjeRHyg8HhkJ6c5vRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.4",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+      "integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@google-cloud/cloud-sql-connector": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/cloud-sql-connector/-/cloud-sql-connector-1.11.1.tgz",
+      "integrity": "sha512-pYFURu8H4Jr5O2KjrN0MdBLKkrChOPiQt+J/KT/DIRwa9cWhFVf2EB6MQxYYv3vQvkB5vEBpTi+TUp4DHZPi6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@googleapis/sqladmin": "^35.2.0",
+        "gaxios": "^7.1.4",
+        "google-auth-library": "^10.6.2",
+        "p-throttle": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.1.tgz",
+      "integrity": "sha512-HtzIe4n9b7It3MjimmFeXwQCuUsPI621e99zBTFqZjbPH7pZpRKDRptlYM0i0+nyot2XXhw0wPfVlTwwR/TyKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.1.tgz",
+      "integrity": "sha512-9HlRbOcDb8b2tSsOvljPD/Rm+Jn9KxMVB6sLf85CBnoIYdCFTNO1FIizQ13P75itXpSXsLuMlg1XK5opHKVzjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-5.0.1.tgz",
+      "integrity": "sha512-yAIqOAlDwx1nPmmA0WICFMSGttVuWX97HpphN71JQ7G+tD/Q6lHbiCTcMJ9r2+PwX6sIwK3ahO4FdSNt5pwhFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.1.tgz",
+      "integrity": "sha512-Ste6NGraHq30ge3Sdq7m+pZE6lRUlkt2YgsEdq/vcoEgdbdZ/7h37Z1dMvivjhlbgrcmYRvlLF9FgI7tXm5wjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-5.3.1.tgz",
+      "integrity": "sha512-xXAQBVVrFviWz8L8yDKEqv1ziVw/gMSpYHt3IxSYRSY0fTyjis+xOrKJILj8dd8PAUHGnGiAIYuTprflkE9jsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/projectify": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "@opentelemetry/api": "~1.9.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "~1.39.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.5.0",
+        "google-gax": "^5.0.5",
+        "google-logging-utils": "^1.1.3",
+        "heap-js": "^2.6.0",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "long": "^5.3.1",
+        "p-defer": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@googleapis/sqladmin": {
+      "version": "35.2.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-35.2.0.tgz",
+      "integrity": "sha512-ajR9EGLs1pCkKfsXxfbVRnQ7ZPyktKNAuahHoU06CVKguWwQo3b9aFmq06PYnGk1oXc0+tlW+XEamNa/HF4pbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/as-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/as-array/-/as-array-2.0.0.tgz",
+      "integrity": "sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth-connect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.1.0.tgz",
+      "integrity": "sha512-rKcWjfiRZ3p5WS9e5q6msXa07s6DaFAMXoyowV+mb2xQG+oYdw2QEUyKi0Xp95JvXzShlM+oGy5QuqSK6TfC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "^1.0.6"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cjson": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.3.tgz",
+      "integrity": "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-parse-helpfulerror": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.3.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-equal-in-any-order": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.2.0.tgz",
+      "integrity": "sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-any": "^4.0.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
+      "dev": true,
+      "license": "public domain"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-listener": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/events-listener/-/events-listener-1.1.0.tgz",
+      "integrity": "sha512-Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/exegesis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/exegesis/-/exegesis-4.3.0.tgz",
+      "integrity": "sha512-V90IJQ4XYO1SfH5qdJTOijXkQTF3hSpSHHqlf7MstUMDKP22iAvi63gweFLtPZ4Gj3Wnh8RgJX5TGu0WiwTyDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.3",
+        "ajv": "^8.3.0",
+        "ajv-formats": "^2.1.0",
+        "body-parser": "^1.18.3",
+        "content-type": "^1.0.4",
+        "deep-freeze": "0.0.1",
+        "events-listener": "^1.1.0",
+        "glob": "^10.3.10",
+        "json-ptr": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "^4.17.11",
+        "openapi3-ts": "^3.1.1",
+        "promise-breaker": "^6.0.0",
+        "qs": "^6.6.0",
+        "raw-body": "^2.3.3",
+        "semver": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis-express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/exegesis-express/-/exegesis-express-4.0.0.tgz",
+      "integrity": "sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "exegesis": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/exegesis/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exegesis/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.14.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.14.0.tgz",
+      "integrity": "sha512-aEZ/lniDR1hOCYpx/x/V8Nrrqq9pepKDNkqP/4WGZFC69gTv6F59Z4/54W/SUP4L/hFlrRNmWj35aweQq+IHow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.13",
+        "@firebase/app-check": "0.11.4",
+        "@firebase/app-check-compat": "0.4.4",
+        "@firebase/app-compat": "0.5.13",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.2",
+        "@firebase/auth-compat": "0.6.7",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.15.0",
+        "@firebase/firestore-compat": "0.4.10",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.4",
+        "@firebase/remote-config-compat": "0.2.25",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/firebase-tools": {
+      "version": "15.19.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.19.1.tgz",
+      "integrity": "sha512-r3BslVykVe0MwvyGf4+oLOcX38vjgEfu2YypfvaQdIW08j505h1mfJrHJGGMmKRAPuvlf35FSekNG9cOfoyh/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apphosting/common": "^0.0.8",
+        "@electric-sql/pglite": "^0.3.3",
+        "@electric-sql/pglite-tools": "^0.2.8",
+        "@google-cloud/cloud-sql-connector": "^1.3.3",
+        "@google-cloud/pubsub": "^5.2.0",
+        "@inquirer/prompts": "^7.10.1",
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "abort-controller": "^3.0.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "3.0.1",
+        "archiver": "^7.0.0",
+        "async-lock": "1.4.1",
+        "body-parser": "^1.19.0",
+        "chokidar": "^3.6.0",
+        "cjson": "^0.3.1",
+        "cli-table3": "0.6.5",
+        "colorette": "^2.0.19",
+        "commander": "^5.1.0",
+        "configstore": "^5.0.1",
+        "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
+        "cross-spawn": "^7.0.5",
+        "csv-parse": "^5.0.4",
+        "deep-equal-in-any-order": "^2.0.6",
+        "exegesis": "^4.2.0",
+        "exegesis-express": "^4.0.0",
+        "express": "^4.16.4",
+        "filesize": "^6.1.0",
+        "form-data": "^4.0.1",
+        "fs-extra": "^10.1.0",
+        "fuzzy": "^0.1.3",
+        "gaxios": "^6.7.0",
+        "glob": "^10.5.0",
+        "google-auth-library": "^9.11.0",
+        "ignore": "^7.0.4",
+        "js-yaml": "^3.14.2",
+        "jsonwebtoken": "^9.0.2",
+        "leven": "^3.1.0",
+        "libsodium-wrappers": "^0.7.10",
+        "lodash": "^4.18.0",
+        "lsofi": "^2.0.0",
+        "marked": "^13.0.2",
+        "marked-terminal": "^7.0.0",
+        "mime": "^2.5.2",
+        "minimatch": "^3.0.4",
+        "morgan": "^1.10.0",
+        "node-fetch": "^2.6.7",
+        "open": "^6.3.0",
+        "ora": "^5.4.1",
+        "p-limit": "^3.0.1",
+        "pg": "^8.11.3",
+        "pg-gateway": "^0.3.0-beta.4",
+        "pglite-2": "npm:@electric-sql/pglite@0.2.17",
+        "portfinder": "^1.0.32",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.3.0",
+        "retry": "^0.13.1",
+        "semver": "^7.5.2",
+        "sql-formatter": "^15.3.0",
+        "stream-chain": "^2.2.4",
+        "stream-json": "^1.7.3",
+        "superstatic": "^10.0.0",
+        "tar": "^7.5.11",
+        "tcp-port-used": "^1.0.2",
+        "tmp": "^0.2.3",
+        "triple-beam": "^1.3.0",
+        "universal-analytics": "^0.5.3",
+        "update-notifier-cjs": "^5.1.6",
+        "uuid": "^11.1.1",
+        "winston": "^3.0.0",
+        "winston-transport": "^4.4.0",
+        "ws": "^7.5.10",
+        "yaml": "^2.8.3",
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "bin": {
+        "firebase": "lib/bin/firebase.js"
+      },
+      "engines": {
+        "node": ">=20.0.0 || >=22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuzzy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+      "integrity": "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-uri/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
+      "integrity": "sha512-ZwFh34WZhZX28ntCMAP1mwyAJkn8+Omagvt/GvA+JQM/qgT0+MR2NPF3vhvgdshfdvDyGZXs8fPXW84K32Wjuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-slasher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
+      "integrity": "sha512-5MUzqFiycIKLMD1B0dYOE4hGgLLUZUNGGYO4BExdwT32wUwW3DBOE7lMQars7vB1q43Fb3Tyt+HmgLKsJhDYdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-slash": "^1.0.0",
+        "lodash.isobject": "^2.4.1",
+        "toxic": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/google-gax/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2.tgz",
+      "integrity": "sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "7.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/heap-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
+      "integrity": "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/install-artifact-from-github": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
+      "integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "bin": {
+        "install-from-cache": "bin/install-from-cache.js",
+        "save-to-github-cache": "bin/save-to-github-cache.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is2": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=v0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/join-path": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/join-path/-/join-path-1.1.1.tgz",
+      "integrity": "sha512-jnt9OC34sLXMLJ6YfPQ2ZEKrR9mB5ZbSnQb4LPaOx1c5rTzxpR33L18jjp0r75mGGTJmsil3qwN1B5IBeTnSSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "as-array": "^2.0.0",
+        "url-join": "0.0.1",
+        "valid-url": "^1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "^1.1.0"
+      }
+    },
+    "node_modules/json-ptr": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-3.1.1.tgz",
+      "integrity": "sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.16.tgz",
+      "integrity": "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.16.tgz",
+      "integrity": "sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.7.16"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lsofi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-2.0.0.tgz",
+      "integrity": "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/morgan": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.4.1",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
+      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.1"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-throttle": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
+      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-gateway": {
+      "version": "0.3.0-beta.4",
+      "resolved": "https://registry.npmjs.org/pg-gateway/-/pg-gateway-0.3.0-beta.4.tgz",
+      "integrity": "sha512-CTjsM7Z+0Nx2/dyZ6r8zRsc3f9FScoD5UAOlfUx1Fdv/JOIWvRbF7gou6l6vP+uypXQVoYPgw8xZDXgMGvBa4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pglite-2": {
+      "name": "@electric-sql/pglite",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/portfinder/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-breaker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-6.0.0.tgz",
+      "integrity": "sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/re2": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.24.1.tgz",
+      "integrity": "sha512-uRl9cLDKuobJQp+6lVz7E3AyVszubUJ0fqAMWout4ocUWTIFvdHgpqLwwMh/vuNGGGJGh2p2mJZJIQr9am9M/A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "install-artifact-from-github": "^1.6.0",
+        "nan": "^2.27.0",
+        "node-gyp": "^12.3.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sort-any": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-4.0.7.tgz",
+      "integrity": "sha512-UuZVEXClHW+bVa6ZBQ4biTWmLXMP7y6/jv5arfA0rKk7ZExy+5Zm19uekIqqDx6ZuvUMu7z5Ba9FfBi6FlGXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.8.1.tgz",
+      "integrity": "sha512-nT2r90kTEYBuse9fe4r1Rp78v1mOBD35KsGc07Vo9eQSVa1TcTSnCS0zouf6BCmdzvmqBsBW+cYuBoYkHO/OWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
+    },
+    "node_modules/sql-formatter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-10.0.0.tgz",
+      "integrity": "sha512-4xIenBdrIIYuqXrIVx/lejyCh4EJwEMPCwfk9VGFfRlhZcdvzTd3oVOUILrAGfC4pFUWixzPgaOVzAEZgeYI3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth-connect": "^1.1.0",
+        "commander": "^10.0.0",
+        "compression": "^1.7.0",
+        "connect": "^3.7.0",
+        "destroy": "^1.0.4",
+        "glob-slasher": "^1.0.1",
+        "is-url": "^1.2.2",
+        "join-path": "^1.1.1",
+        "lodash": "^4.17.19",
+        "mime-types": "^2.1.35",
+        "minimatch": "^6.1.6",
+        "morgan": "^1.8.2",
+        "on-finished": "^2.2.0",
+        "on-headers": "^1.0.0",
+        "path-to-regexp": "^1.9.0",
+        "router": "^2.0.0",
+        "update-notifier-cjs": "^5.1.6"
+      },
+      "bin": {
+        "superstatic": "lib/bin/server.js"
+      },
+      "engines": {
+        "node": "20 || 22 || 24"
+      },
+      "optionalDependencies": {
+        "re2": "^1.17.7"
+      }
+    },
+    "node_modules/superstatic/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/superstatic/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/superstatic/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic/node_modules/minimatch": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.3.tgz",
+      "integrity": "sha512-5rvZbDy5y2k40rre/0OBbYnl03en25XPU3gOVO7532beGMjAipq88VdS9OeLOZNrD+Tb0lDhBJHZ7Gcd8qKlPg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superstatic/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/teeny-request/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/to-regex-range/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/toxic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
+      "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universal-analytics": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.5.4.tgz",
+      "integrity": "sha512-db38BYsx+oZEx0bc+PeGmIwG+YiYH5Xluhxf9EBnL39U4+DAXJtXQHLJ+zzTH36lx/N54/WKQQYnh0kQWJ74yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/universal-analytics/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/universal-analytics/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-analytics/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-notifier-cjs": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz",
+      "integrity": "sha512-eZWTh8F+VCEoC4UIh0pKmh8h4izj65VvLhCpJpVefUxdYe0fU3GBrC4Sbh1AoWA/miNPAb6UVlp2fUQNsfp+3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "isomorphic-fetch": "^3.0.0",
+        "pupa": "^2.1.1",
+        "registry-auth-token": "^5.0.1",
+        "registry-url": "^5.1.0",
+        "semver": "^7.3.7",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/update-notifier-cjs/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
+      "dev": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/firebase/test/package.json
+++ b/firebase/test/package.json
@@ -18,6 +18,6 @@
     "firebase": "^12.0.0",
     "firebase-tools": "^15.0.0",
     "typescript": "^5.5.0",
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/firebase/test/package.json
+++ b/firebase/test/package.json
@@ -16,7 +16,7 @@
     "@firebase/rules-unit-testing": "^5.0.1",
     "@types/node": "^22.10.0",
     "firebase": "^12.0.0",
-    "firebase-tools": "^14.0.0",
+    "firebase-tools": "^15.0.0",
     "typescript": "^5.5.0",
     "vitest": "^2.1.8"
   }

--- a/firebase/test/package.json
+++ b/firebase/test/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@trails/firestore-rules-test",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Firestore security-rules unit tests (emulator + @firebase/rules-unit-testing). Standalone — not part of the warg pnpm workspace.",
+  "engines": {
+    "node": "22"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "firebase emulators:exec --only firestore --project=demo-trails --config=../firebase.json 'vitest run'",
+    "test:watch": "firebase emulators:exec --only firestore --project=demo-trails --config=../firebase.json 'vitest'"
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.1",
+    "@types/node": "^22.10.0",
+    "firebase": "^12.0.0",
+    "firebase-tools": "^14.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/firebase/test/tsconfig.json
+++ b/firebase/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/firebase/test/vitest.config.ts
+++ b/firebase/test/vitest.config.ts
@@ -6,9 +6,8 @@ export default defineConfig({
     // The emulator is shared process-wide; a single fork keeps clearFirestore()
     // between tests from racing parallel workers.
     pool: 'forks',
-    poolOptions: {
-      forks: { singleFork: true },
-    },
+    maxWorkers: 1,
+    isolate: false,
     testTimeout: 30_000,
     hookTimeout: 30_000,
   },

--- a/firebase/test/vitest.config.ts
+++ b/firebase/test/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // The emulator is shared process-wide; a single fork keeps clearFirestore()
+    // between tests from racing parallel workers.
+    pool: 'forks',
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/shared-types/MarkerSchema.md
+++ b/shared-types/MarkerSchema.md
@@ -22,11 +22,11 @@ also mirrors the marker doc's `key` field.
 These are the literal Firestore document field names. **Renaming any of these
 requires updating every producer and the rules/tests in the same commit.**
 
-| Field       | Type                  | Producer(s) | Notes |
-| ----------- | --------------------- | ----------- | ----- |
-| `key`       | string                | required    | The article key this marker covers (mirrors the doc id). |
-| `createdAt` | timestamp             | required    | Server timestamp; markers are merge-written, so this carries last-write (not first-seen) semantics — acceptable for existence markers. |
-| `source`    | string                | required    | Provenance: `sync` \| `self-heal` \| `backfill`. |
+| Field       | Type                  | Required | Notes |
+| ----------- | --------------------- | -------- | ----- |
+| `key`       | string                | required | The article key this marker covers (mirrors the doc id). |
+| `createdAt` | timestamp             | required | Server timestamp; markers are merge-written, so this carries last-write (not first-seen) semantics — acceptable for existence markers. |
+| `source`    | string                | required | Provenance: `sync` \| `self-heal` \| `backfill`. |
 
 ## Producers
 

--- a/shared-types/MarkerSchema.md
+++ b/shared-types/MarkerSchema.md
@@ -34,8 +34,11 @@ requires updating every producer and the rules/tests in the same commit.**
   article key on backup (`source: "sync"`) and on read-denial self-heal
   (`source: "self-heal"`), via the `ARTICLE_MARKERS_COLLECTION` constant.
   [`android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt`](../android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt)
-- **Warg backfill (planned)** — a one-off Admin SDK backfill writes the same
-  docs with `source: "backfill"` for historical articles.
+- **Warg backfill** — the Admin-SDK `@warg/backfill-scripts` package writes the
+  same docs with `source: "backfill"` for historical articles, deriving keys via
+  the shared `ARTICLE_MARKERS_COLLECTION` constant + `deriveMarkerKeys` (parity
+  port of the Android `markerKeysFor`).
+  [`warg/cloud-functions/backfill-scripts/src/keys.ts`](../warg/cloud-functions/backfill-scripts/src/keys.ts)
 
 ## Consumer
 
@@ -49,6 +52,7 @@ written for every key.
 1. Update the table above.
 2. Update `markerBody(...)` and the `ARTICLE_MARKERS_COLLECTION` constant in
    `FirestoreBackupService.kt`.
-3. Update the Warg backfill writer when it is added.
+3. Update `deriveMarkerKeys`/`markerBody` and the `ARTICLE_MARKERS_COLLECTION`
+   constant in `warg/cloud-functions/backfill-scripts/src/keys.ts`.
 4. Update `firebase/firestore.rules` and `firebase/test/firestore-rules.test.ts`.
 5. Run `node --experimental-strip-types shared-types/check-drift.ts` locally.

--- a/shared-types/MarkerSchema.md
+++ b/shared-types/MarkerSchema.md
@@ -1,0 +1,54 @@
+# Canonical schema: `users/{uid}/articleMarkers/{key}`
+
+Per-user article-existence markers. One marker doc is written for every saved
+article key (its `itemId`, plus `resolvedId` when present and distinct). The
+tightened top-level `articles` read rule — a later, separately deployed change —
+gates a read on the existence of a matching marker, so every stack that creates
+markers must agree on the path and field names.
+
+Enforced by `shared-types/check-drift.ts`, which runs in CI.
+
+## Path
+
+```
+users/{uid}/articleMarkers/{key}
+```
+
+`{key}` is the article key the marker covers (`itemId` or `resolvedId`); it
+also mirrors the marker doc's `key` field.
+
+## Firestore field names
+
+These are the literal Firestore document field names. **Renaming any of these
+requires updating every producer and the rules/tests in the same commit.**
+
+| Field       | Type                  | Producer(s) | Notes |
+| ----------- | --------------------- | ----------- | ----- |
+| `key`       | string                | required    | The article key this marker covers (mirrors the doc id). |
+| `createdAt` | timestamp             | required    | Server timestamp; markers are merge-written, so this carries last-write (not first-seen) semantics — acceptable for existence markers. |
+| `source`    | string                | required    | Provenance: `sync` \| `self-heal` \| `backfill`. |
+
+## Producers
+
+- **Trails (Android)** — `FirestoreBackupService` writes a marker for every
+  article key on backup (`source: "sync"`) and on read-denial self-heal
+  (`source: "self-heal"`), via the `ARTICLE_MARKERS_COLLECTION` constant.
+  [`android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt`](../android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt)
+- **Warg backfill (planned)** — a one-off Admin SDK backfill writes the same
+  docs with `source: "backfill"` for historical articles.
+
+## Consumer
+
+The tightened `articles` read rule — a later, separately deployed change — will check
+`exists(/databases/$(database)/documents/users/$(uid)/articleMarkers/$(itemId))`.
+A single `exists()` covers whichever key a reader passes, because a marker is
+written for every key.
+
+## Adding or changing a field
+
+1. Update the table above.
+2. Update `markerBody(...)` and the `ARTICLE_MARKERS_COLLECTION` constant in
+   `FirestoreBackupService.kt`.
+3. Update the Warg backfill writer when it is added.
+4. Update `firebase/firestore.rules` and `firebase/test/firestore-rules.test.ts`.
+5. Run `node --experimental-strip-types shared-types/check-drift.ts` locally.

--- a/shared-types/MarkerSchema.md
+++ b/shared-types/MarkerSchema.md
@@ -25,6 +25,7 @@ requires updating every producer and the rules/tests in the same commit.**
 | Field       | Type                  | Required | Notes |
 | ----------- | --------------------- | -------- | ----- |
 | `key`       | string                | required | The article key this marker covers (mirrors the doc id). |
+| `itemId`    | string                | required | The doc id of the user's own article at `users/{uid}/articles/{itemId}`. Both the itemId-keyed and the resolvedId-keyed marker for the same article carry the same `itemId`. Required by the tightened marker create/update rule (`getAfter` on `users/{uid}/articles/{itemId}`). |
 | `createdAt` | timestamp             | required | Server timestamp; markers are merge-written, so this carries last-write (not first-seen) semantics — acceptable for existence markers. |
 | `source`    | string                | required | Provenance: `sync` \| `self-heal` \| `backfill`. |
 
@@ -51,8 +52,9 @@ written for every key.
 
 1. Update the table above.
 2. Update `markerBody(...)` and the `ARTICLE_MARKERS_COLLECTION` constant in
-   `FirestoreBackupService.kt`.
+   `FirestoreBackupService.kt`. Note `markerBody` takes `(key, source, articleItemId)`.
 3. Update `deriveMarkerKeys`/`markerBody` and the `ARTICLE_MARKERS_COLLECTION`
-   constant in `warg/cloud-functions/backfill-scripts/src/keys.ts`.
+   constant in `warg/cloud-functions/backfill-scripts/src/keys.ts`. Note `markerBody`
+   takes `(key, itemId, source?)` in the TS producer.
 4. Update `firebase/firestore.rules` and `firebase/test/firestore-rules.test.ts`.
 5. Run `node --experimental-strip-types shared-types/check-drift.ts` locally.

--- a/shared-types/check-drift.ts
+++ b/shared-types/check-drift.ts
@@ -1,11 +1,17 @@
 /**
  * Cross-stack schema drift check.
  *
- * Verifies that the canonical Firestore field names defined in
- * `shared-types/WargMetadata.md` actually appear in both the Warg producer
- * (TypeScript) and the Trails consumer (Kotlin). This is a defensive smoke
- * check, not a parser — it catches accidental renames or typos but won't
- * catch deeper semantic drift (type changes, nullability mismatches).
+ * Verifies two contracts:
+ *  1. The canonical Firestore field names in `shared-types/WargMetadata.md`
+ *     appear in both the Warg producer (TypeScript) and the Trails consumer
+ *     (Kotlin).
+ *  2. The marker contract in `shared-types/MarkerSchema.md`
+ *     (users/{uid}/articleMarkers/{key}) — its collection name and field names
+ *     appear in the Trails marker writer (FirestoreBackupService.kt).
+ *
+ * This is a defensive smoke check, not a parser — it catches accidental
+ * renames or typos but won't catch deeper semantic drift (type changes,
+ * nullability mismatches).
  *
  * Run from monorepo root:
  *   node --experimental-strip-types shared-types/check-drift.ts
@@ -28,6 +34,14 @@ const WARG_TYPES = resolve(repoRoot, 'warg/cloud-functions/archive-gateway/src/t
 const TRAILS_SOURCE = resolve(
   repoRoot,
   'android/app/src/main/java/com/jayteealao/trails/data/archive/ArchiveService.kt',
+);
+
+// Marker contract: users/{uid}/articleMarkers/{key} — see MarkerSchema.md.
+const MARKER_DOC = resolve(here, 'MarkerSchema.md');
+const MARKER_COLLECTION = 'articleMarkers';
+const TRAILS_MARKER_WRITER = resolve(
+  repoRoot,
+  'android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt',
 );
 
 // Trails only reads a subset of fields; fields listed here are exempt from
@@ -58,8 +72,49 @@ function extractCanonicalFields(md: string): string[] {
   return fields;
 }
 
+// Marker field names are camelCase (e.g. `createdAt`), so they need a parser
+// that allows uppercase letters — unlike the snake_case WargMetadata fields.
+function extractMarkerFields(md: string): string[] {
+  const fields: string[] = [];
+  for (const line of md.split('\n')) {
+    const match = line.match(/^\|\s*`([a-zA-Z_][a-zA-Z0-9_]*)`\s*\|/);
+    if (match) fields.push(match[1]);
+  }
+  if (fields.length === 0) {
+    console.error('[drift] no fields parsed from MarkerSchema.md — table format changed?');
+    process.exit(1);
+  }
+  return fields;
+}
+
 function findMissing(haystack: string, needles: readonly string[]): string[] {
   return needles.filter((needle) => !haystack.includes(needle));
+}
+
+// Returns true if marker-contract drift was detected.
+function checkMarkerContract(): boolean {
+  const markerFields = extractMarkerFields(readFile(MARKER_DOC));
+  console.log(`[drift] marker fields: ${markerFields.join(', ')}`);
+
+  const writerSrc = readFile(TRAILS_MARKER_WRITER);
+  let drift = false;
+
+  if (!writerSrc.includes(MARKER_COLLECTION)) {
+    console.error(
+      `[drift] FirestoreBackupService.kt does not reference the marker collection "${MARKER_COLLECTION}".`,
+    );
+    drift = true;
+  }
+
+  const missing = findMissing(writerSrc, markerFields);
+  if (missing.length > 0) {
+    console.error(
+      `[drift] FirestoreBackupService.kt is missing marker field name(s): ${missing.join(', ')}`,
+    );
+    drift = true;
+  }
+
+  return drift;
 }
 
 function main(): void {
@@ -87,12 +142,17 @@ function main(): void {
     drift = true;
   }
 
+  // Marker contract (users/{uid}/articleMarkers/{key}).
+  if (checkMarkerContract()) {
+    drift = true;
+  }
+
   if (drift) {
-    console.error('[drift] FAIL — update shared-types/WargMetadata.md or the affected source.');
+    console.error('[drift] FAIL — update shared-types/*.md or the affected source.');
     process.exit(1);
   }
 
-  console.log('[drift] OK — both sides reference all canonical fields.');
+  console.log('[drift] OK — metadata and marker contracts both intact.');
 }
 
 main();

--- a/shared-types/check-drift.ts
+++ b/shared-types/check-drift.ts
@@ -43,6 +43,12 @@ const TRAILS_MARKER_WRITER = resolve(
   repoRoot,
   'android/app/src/main/java/com/jayteealao/trails/services/firestore/FirestoreBackupService.kt',
 );
+// Second marker producer: the Warg Admin-SDK backfill. Its pure key module is
+// the source of truth for the collection name + field body it writes.
+const WARG_MARKER_BACKFILL = resolve(
+  repoRoot,
+  'warg/cloud-functions/backfill-scripts/src/keys.ts',
+);
 
 // Trails only reads a subset of fields; fields listed here are exempt from
 // the Trails-side check.
@@ -91,30 +97,50 @@ function findMissing(haystack: string, needles: readonly string[]): string[] {
   return needles.filter((needle) => !haystack.includes(needle));
 }
 
-// Returns true if marker-contract drift was detected.
-function checkMarkerContract(): boolean {
-  const markerFields = extractMarkerFields(readFile(MARKER_DOC));
-  console.log(`[drift] marker fields: ${markerFields.join(', ')}`);
-
-  const writerSrc = readFile(TRAILS_MARKER_WRITER);
+// Assert one marker producer references the collection name + every field.
+// Returns true if drift was detected for that producer.
+function checkMarkerProducer(
+  label: string,
+  path: string,
+  markerFields: readonly string[],
+): boolean {
+  const src = readFile(path);
   let drift = false;
 
-  if (!writerSrc.includes(MARKER_COLLECTION)) {
+  if (!src.includes(MARKER_COLLECTION)) {
     console.error(
-      `[drift] FirestoreBackupService.kt does not reference the marker collection "${MARKER_COLLECTION}".`,
+      `[drift] ${label} does not reference the marker collection "${MARKER_COLLECTION}".`,
     );
     drift = true;
   }
 
-  const missing = findMissing(writerSrc, markerFields);
+  const missing = findMissing(src, markerFields);
   if (missing.length > 0) {
-    console.error(
-      `[drift] FirestoreBackupService.kt is missing marker field name(s): ${missing.join(', ')}`,
-    );
+    console.error(`[drift] ${label} is missing marker field name(s): ${missing.join(', ')}`);
     drift = true;
   }
 
   return drift;
+}
+
+// Returns true if marker-contract drift was detected in any producer.
+function checkMarkerContract(): boolean {
+  const markerFields = extractMarkerFields(readFile(MARKER_DOC));
+  console.log(`[drift] marker fields: ${markerFields.join(', ')}`);
+
+  // Both producers must agree on the path + field names.
+  const trailsDrift = checkMarkerProducer(
+    'FirestoreBackupService.kt',
+    TRAILS_MARKER_WRITER,
+    markerFields,
+  );
+  const wargDrift = checkMarkerProducer(
+    'backfill-scripts/src/keys.ts',
+    WARG_MARKER_BACKFILL,
+    markerFields,
+  );
+
+  return trailsDrift || wargDrift;
 }
 
 function main(): void {

--- a/warg/README.md
+++ b/warg/README.md
@@ -45,14 +45,18 @@ pnpm --filter @warg/gateway dev
 ## Structure
 
 - `workers/` - Cloudflare Workers
-  - `gateway/` - Public API (POST /begin, GET /status/:id)
-  - `workflow/` - Orchestration workflow
+  - `gateway/` - Public API (POST /begin, GET /status/:id) + cron sweeps
+  - `workflow/` - Orchestration workflow + browser/sandbox quota DO
   - `renderer/` - Browser rendering
   - `singlefile/` - SingleFile HTML extraction
   - `readability/` - Readability extraction
-  - `monolith/` - Monolith HTML extraction
+  - `monolith/` - Monolith HTML extraction (sandbox container, stopped per job — see its README)
+  - `logger/` - Event-sourced request traces (hour-bucketed Durable Objects — see its README)
   - `gcs/` - GCS persistence coordinator
 - `packages/shared/` - Shared types and utilities
 - `cloud-functions/archive-gateway/` - Google Cloud Function for GCS/Firestore
+- `docs/` - Decision records
 
-All workers are placeholders returning 501 Not Implemented.
+Cost note: Durable Object duration (GB-s) is the dominant billing meter for
+this pipeline; see `docs/adr-do-cost.md` for the container and logger
+lifecycle decisions that keep it under the free tier.

--- a/warg/cloud-functions/archive-gateway/package.json
+++ b/warg/cloud-functions/archive-gateway/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.15.0",
-    "firebase-admin": "^13.0.2",
+    "firebase-admin": "^13.10.0",
     "firebase-functions": "^6.3.0"
   },
   "devDependencies": {

--- a/warg/cloud-functions/archive-gateway/src/create-upload.ts
+++ b/warg/cloud-functions/archive-gateway/src/create-upload.ts
@@ -8,8 +8,7 @@ import type {
   UploadEntry,
   ArticleDocument,
   ArtifactKind,
-  ArchiveEntry,
-  ArtifactUploadInfo
+  ArchiveEntry
 } from './types.js';
 import { GCS_PATH_CONFIG, KIND_TO_ARCHIVE_KEY } from './types.js';
 import { logEvent } from './logging.js';

--- a/warg/cloud-functions/backfill-archiver/package.json
+++ b/warg/cloud-functions/backfill-archiver/package.json
@@ -13,7 +13,7 @@
     "node": "22"
   },
   "dependencies": {
-    "firebase-admin": "^13.0.2",
+    "firebase-admin": "^13.10.0",
     "firebase-functions": "^6.3.0"
   },
   "devDependencies": {

--- a/warg/cloud-functions/backfill-archiver/src/index.ts
+++ b/warg/cloud-functions/backfill-archiver/src/index.ts
@@ -607,7 +607,7 @@ export const backfillArchiver = onSchedule(
       return;
     }
 
-    let tracker = loadedTracker;
+    const tracker = loadedTracker;
 
     try {
       pruneExpiredDomainBackoff(tracker, Date.now());

--- a/warg/cloud-functions/backfill-scripts/README.md
+++ b/warg/cloud-functions/backfill-scripts/README.md
@@ -1,0 +1,102 @@
+# @warg/backfill-scripts
+
+Operator-run Admin-SDK maintenance CLIs that make the tightened top-level
+`articles` read rule safe to deploy. The Admin SDK bypasses Firestore security
+rules, so these run as a trusted operator (via ADC), never as the app.
+
+Three independent scripts share a small pure core (`keys` / `coverage` /
+`classify`):
+
+| Script | What it does | Destructive? |
+| ------ | ------------ | ------------ |
+| `marker-backfill` | Writes a `users/{uid}/articleMarkers/{key}` doc for every key of every one of the user's articles (`itemId`, plus `resolvedId` when present and distinct). Writes **only missing** keys; preserves any existing marker's `source`/`createdAt`. | No — never deletes. |
+| `coverage-gate` | Asserts a marker exists for every derived key. Prints the headline counts and exits non-zero on any gap. This is the precondition that authorizes the read-rule flip. | No — read-only. |
+| `debug-logs-cleanup` | Deletes the legacy flat `debug_logs/{id}` docs left unreadable after the uid-scoped `debug_logs/{uid}/sessions/*` migration. Classifies by field shape **and** the absence of a `sessions` subcollection. | Yes — only on `--apply`, only on `legacy-flat` docs. |
+
+## Preconditions
+
+1. **Application Default Credentials** with access to `trails-e428e`:
+
+   ```sh
+   gcloud auth application-default login
+   ```
+
+   `initializeApp()` is called with no credential argument and picks up ADC.
+   Without it, the first Firestore call fails with an auth error (not a bug in
+   these scripts).
+
+2. **Node 22** and a built `dist/` (the scripts are plain compiled JS):
+
+   ```sh
+   pnpm --filter @warg/backfill-scripts build
+   ```
+
+## Prod vs. emulator targeting
+
+Every write/delete script calls `assertTargetEnv()` before touching data:
+
+- If `FIRESTORE_EMULATOR_HOST` is set, it logs `targeting EMULATOR <host>` and
+  proceeds immediately.
+- Otherwise it logs `targeting PRODUCTION trails-e428e` and waits **5 seconds**
+  (Ctrl-C to abort) before continuing. Pass `--yes` to skip the wait in a
+  non-interactive context.
+
+Never hardcode `FIRESTORE_EMULATOR_HOST`; set it in the environment when you
+want the emulator.
+
+## CLI flags
+
+All three scripts accept:
+
+- `--user <uid>` — target user. Defaults to the single production user
+  (`TGtRF6GrQaSmfjGk9GEYJ8YZc0v1`). The other accounts are test users covered by
+  the app's steady-state marker write + read-denial self-heal.
+- `--apply` — perform writes/deletes. **Omitted = dry-run** (the default): the
+  script reports exact counts and a sample of affected keys/ids without
+  changing anything.
+- `--limit <n>` — cap the number of articles scanned (backfill / gate), for a
+  quick sample run.
+
+## Dry-run-first workflow
+
+```sh
+# 0. build
+pnpm --filter @warg/backfill-scripts build
+
+# 1. backfill — review counts first, then apply
+node dist/marker-backfill.js                 # dry-run: prints wouldWrite / alreadyPresent
+node dist/marker-backfill.js --apply         # writes only the missing markers
+
+# 2. gate — must exit 0 before the read-rule flip is deployed
+node dist/coverage-gate.js                   # exits 0 when covered, 1 on any gap
+
+# 3. cleanup — review, then apply, then confirm 0 remain
+node dist/debug-logs-cleanup.js              # dry-run: legacy-flat count + sample ids
+node dist/debug-logs-cleanup.js --apply      # recursiveDelete each legacy-flat doc
+node dist/debug-logs-cleanup.js              # dry-run again: expect 0
+```
+
+## Deploy ordering (important)
+
+The tightened `articles` read rule must be the **last** change to merge, because
+merging `firebase/**` auto-deploys the rules. Run the backfill `--apply` and a
+**passing** `coverage-gate` against production **before** that final rules
+change lands. Backfill and the gate are deploy-safe to run any time — the read
+rule they protect is not yet tightened.
+
+## Tests
+
+```sh
+# pure unit tests (no emulator, CI-safe) — key derivation, coverage, classifier
+pnpm --filter @warg/backfill-scripts test
+
+# emulator integration tests (local / on-demand) — real writes, gate exit codes,
+# cleanup targeting. Boots the Firestore emulator on the shared port (8080).
+firebase emulators:exec --only firestore --project=demo-trails \
+  --config=../../../firebase/firebase.json \
+  'pnpm --filter @warg/backfill-scripts test:integration'
+```
+
+The integration suite defaults `FIRESTORE_EMULATOR_HOST` to `127.0.0.1:8080`
+when unset, so it also runs against an already-running emulator with no extra
+environment setup.

--- a/warg/cloud-functions/backfill-scripts/README.md
+++ b/warg/cloud-functions/backfill-scripts/README.md
@@ -48,9 +48,9 @@ want the emulator.
 
 All three scripts accept:
 
-- `--user <uid>` — target user. Defaults to the single production user
-  (`TGtRF6GrQaSmfjGk9GEYJ8YZc0v1`). The other accounts are test users covered by
-  the app's steady-state marker write + read-denial self-heal.
+- `--user <uid>` — target user (**required** — no default). Pass the uid
+  explicitly, or export `BACKFILL_USER_ID=<uid>` in the environment. Omitting
+  both causes the script to exit with a clear error.
 - `--apply` — perform writes/deletes. **Omitted = dry-run** (the default): the
   script reports exact counts and a sample of affected keys/ids without
   changing anything.
@@ -63,12 +63,16 @@ All three scripts accept:
 # 0. build
 pnpm --filter @warg/backfill-scripts build
 
+# Set the target uid (or pass --user <uid> to each command below)
+export BACKFILL_USER_ID=<your-uid>
+
 # 1. backfill — review counts first, then apply
 node dist/marker-backfill.js                 # dry-run: prints wouldWrite / alreadyPresent
 node dist/marker-backfill.js --apply         # writes only the missing markers
 
 # 2. gate — must exit 0 before the read-rule flip is deployed
 node dist/coverage-gate.js                   # exits 0 when covered, 1 on any gap
+                                             # (--limit is rejected by the gate)
 
 # 3. cleanup — review, then apply, then confirm 0 remain
 node dist/debug-logs-cleanup.js              # dry-run: legacy-flat count + sample ids

--- a/warg/cloud-functions/backfill-scripts/package.json
+++ b/warg/cloud-functions/backfill-scripts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@warg/backfill-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Admin-SDK maintenance CLIs for the article-marker rollout: bulk marker backfill, a per-user coverage gate, and legacy debug_logs cleanup. Single-user scoped, dry-run-first, never destructive in the backfill path.",
+  "engines": {
+    "node": "22"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "pnpm run build && node --test \"dist/__tests__/*.unit.test.js\"",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "backfill": "node dist/marker-backfill.js",
+    "gate": "node dist/coverage-gate.js",
+    "cleanup": "node dist/debug-logs-cleanup.js"
+  },
+  "dependencies": {
+    "firebase-admin": "^13.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/warg/cloud-functions/backfill-scripts/package.json
+++ b/warg/cloud-functions/backfill-scripts/package.json
@@ -17,11 +17,11 @@
     "cleanup": "node dist/debug-logs-cleanup.js"
   },
   "dependencies": {
-    "firebase-admin": "^13.0.2"
+    "firebase-admin": "^13.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/classify.unit.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/classify.unit.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyDebugLogDoc } from '../classify.js';
+
+test('classify: legacy-flat = events[] + sessionId + device, no sessions subcollection', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'abc12345_session',
+    data: { events: [], sessionId: 'abc12345', device: 'Pixel 7' },
+    hasSessionsSubcollection: false,
+  });
+  assert.equal(cls, 'legacy-flat');
+});
+
+test('classify: owner-parent = has a sessions subcollection (never deleted)', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'uid-1',
+    data: undefined,
+    hasSessionsSubcollection: true,
+  });
+  assert.equal(cls, 'owner-parent');
+});
+
+test('classify: subcollection guard wins even when flat-shaped fields are present', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'uid-1',
+    data: { events: [], sessionId: 's', device: 'p' },
+    hasSessionsSubcollection: true,
+  });
+  assert.equal(cls, 'owner-parent');
+});
+
+test('classify: unknown when device is missing', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'x',
+    data: { events: [], sessionId: 's' },
+    hasSessionsSubcollection: false,
+  });
+  assert.equal(cls, 'unknown');
+});
+
+test('classify: unknown when events is not an array', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'x',
+    data: { events: 'nope', sessionId: 's', device: 'p' },
+    hasSessionsSubcollection: false,
+  });
+  assert.equal(cls, 'unknown');
+});
+
+test('classify: unknown for a missing/empty doc with no subcollection', () => {
+  const cls = classifyDebugLogDoc({
+    id: 'x',
+    data: undefined,
+    hasSessionsSubcollection: false,
+  });
+  assert.equal(cls, 'unknown');
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/coverage-gate.int.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/coverage-gate.int.test.ts
@@ -1,0 +1,57 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { userArticlesCollection } from '../articles.js';
+import { computeUserCoverage } from '../coverage-gate.js';
+import { backfillMarkers } from '../marker-backfill.js';
+import { clearEmulator, createTestDb, destroyTestDb } from './emulator.js';
+import type { TestDb } from './emulator.js';
+
+const USER = 'TEST_USER';
+
+let testDb: TestDb;
+let db: Firestore;
+
+beforeAll(() => {
+  testDb = createTestDb();
+  db = testDb.db;
+});
+
+afterAll(async () => {
+  await destroyTestDb(testDb);
+});
+
+afterEach(async () => {
+  await clearEmulator();
+});
+
+async function seedArticle(
+  itemId: string,
+  fields: Record<string, unknown> = {},
+): Promise<void> {
+  await userArticlesCollection(db, USER).doc(itemId).set({ itemId, ...fields });
+}
+
+describe('coverage gate (emulator)', () => {
+  it('reports a gap (covered=false) before any markers exist', async () => {
+    await seedArticle('a1');
+    await seedArticle('a2', { resolvedId: 'r2' });
+
+    const result = await computeUserCoverage(db, USER);
+
+    expect(result.covered).toBe(false);
+    expect(result.expectedCount).toBe(3); // a1, a2, r2
+    expect([...result.missing].sort()).toEqual(['a1', 'a2', 'r2']);
+  });
+
+  it('reports full coverage (covered=true) after backfill --apply', async () => {
+    await seedArticle('a1');
+    await seedArticle('a2', { resolvedId: 'r2' });
+    await backfillMarkers(db, { user: USER, apply: true, limit: Number.POSITIVE_INFINITY });
+
+    const result = await computeUserCoverage(db, USER);
+
+    expect(result.covered).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/coverage.unit.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/coverage.unit.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { computeCoverage } from '../coverage.js';
+
+test('computeCoverage: full coverage (existing superset of expected)', () => {
+  const result = computeCoverage(new Set(['a', 'b']), new Set(['a', 'b', 'c']));
+  assert.equal(result.covered, true);
+  assert.deepEqual(result.missing, []);
+  assert.equal(result.expectedCount, 2);
+  assert.equal(result.existingCount, 3);
+});
+
+test('computeCoverage: exact coverage', () => {
+  const result = computeCoverage(new Set(['a', 'b']), new Set(['a', 'b']));
+  assert.equal(result.covered, true);
+  assert.deepEqual(result.missing, []);
+});
+
+test('computeCoverage: partial coverage reports the missing keys', () => {
+  const result = computeCoverage(new Set(['a', 'b', 'c']), new Set(['a']));
+  assert.equal(result.covered, false);
+  assert.deepEqual([...result.missing].sort(), ['b', 'c']);
+});
+
+test('computeCoverage: empty expected is trivially covered', () => {
+  const result = computeCoverage(new Set(), new Set());
+  assert.equal(result.covered, true);
+  assert.equal(result.expectedCount, 0);
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/coverage.unit.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/coverage.unit.test.ts
@@ -28,3 +28,15 @@ test('computeCoverage: empty expected is trivially covered', () => {
   assert.equal(result.covered, true);
   assert.equal(result.expectedCount, 0);
 });
+
+// When a --limit sample is applied, `expected` contains only the sampled keys
+// while `existing` may hold more. Extra existing keys must not affect coverage.
+test('computeCoverage: limit-sampled expected covered by larger existing set', () => {
+  // Simulates: limit=2 sampled keys ['a','b']; user already has markers for
+  // those plus additional historical keys ['c','d'].
+  const result = computeCoverage(new Set(['a', 'b']), new Set(['a', 'b', 'c', 'd']));
+  assert.equal(result.covered, true);
+  assert.deepEqual(result.missing, []);
+  assert.equal(result.expectedCount, 2);
+  assert.equal(result.existingCount, 4);
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/debug-logs-cleanup.int.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/debug-logs-cleanup.int.test.ts
@@ -1,0 +1,80 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupDebugLogs } from '../debug-logs-cleanup.js';
+import { clearEmulator, createTestDb, destroyTestDb } from './emulator.js';
+import type { TestDb } from './emulator.js';
+
+let testDb: TestDb;
+let db: Firestore;
+
+beforeAll(() => {
+  testDb = createTestDb();
+  db = testDb.db;
+});
+
+afterAll(async () => {
+  await destroyTestDb(testDb);
+});
+
+afterEach(async () => {
+  await clearEmulator();
+});
+
+async function seedLegacyFlat(id: string): Promise<void> {
+  await db
+    .collection('debug_logs')
+    .doc(id)
+    .set({ sessionId: id, device: 'Pixel 7', events: [] });
+}
+
+async function seedOwnerSession(uid: string, sessionDocId: string): Promise<void> {
+  // A session doc under debug_logs/{uid}/sessions/* — the parent debug_logs/{uid}
+  // is a "missing" doc that only owns the sessions subcollection.
+  await db
+    .collection('debug_logs')
+    .doc(uid)
+    .collection('sessions')
+    .doc(sessionDocId)
+    .set({ sessionId: sessionDocId, events: [] });
+}
+
+describe('debug_logs cleanup (emulator)', () => {
+  it('deletes a legacy flat doc and preserves a uid-scoped sessions parent', async () => {
+    await seedLegacyFlat('abc12345_session');
+    await seedOwnerSession('uid-1', 'sess-1_a1');
+
+    const dry = await cleanupDebugLogs(db, { apply: false, limit: Number.POSITIVE_INFINITY });
+    expect(dry.legacyFlat).toBe(1);
+    expect(dry.ownerParent).toBe(1);
+    expect(dry.deleted).toBe(0);
+
+    const applied = await cleanupDebugLogs(db, {
+      apply: true,
+      limit: Number.POSITIVE_INFINITY,
+    });
+    expect(applied.deleted).toBe(1);
+    expect(applied.errors).toBe(0);
+
+    const legacy = await db.collection('debug_logs').doc('abc12345_session').get();
+    expect(legacy.exists).toBe(false);
+
+    const session = await db
+      .collection('debug_logs')
+      .doc('uid-1')
+      .collection('sessions')
+      .doc('sess-1_a1')
+      .get();
+    expect(session.exists).toBe(true);
+  });
+
+  it('never deletes during a dry-run, even with legacy docs present', async () => {
+    await seedLegacyFlat('abc12345_session');
+
+    const dry = await cleanupDebugLogs(db, { apply: false, limit: Number.POSITIVE_INFINITY });
+    expect(dry.deleted).toBe(0);
+
+    const legacy = await db.collection('debug_logs').doc('abc12345_session').get();
+    expect(legacy.exists).toBe(true);
+  });
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/emulator.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/emulator.ts
@@ -1,0 +1,43 @@
+import process from 'node:process';
+
+import { deleteApp, initializeApp } from 'firebase-admin/app';
+import type { App } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
+
+const PROJECT_ID = 'demo-trails';
+
+// Default to the shared emulator port when the suite is not launched via
+// `firebase emulators:exec` (which sets FIRESTORE_EMULATOR_HOST itself). This
+// keeps the integration suite cross-platform — no shell env-var prefix needed.
+process.env['FIRESTORE_EMULATOR_HOST'] ??= '127.0.0.1:8080';
+process.env['GCLOUD_PROJECT'] ??= PROJECT_ID;
+
+let appCounter = 0;
+
+export interface TestDb {
+  readonly db: Firestore;
+  readonly app: App;
+}
+
+/** A fresh Admin app + Firestore pointed at the emulator (no real credentials). */
+export function createTestDb(): TestDb {
+  const app = initializeApp({ projectId: PROJECT_ID }, `int-test-${appCounter++}`);
+  return { db: getFirestore(app), app };
+}
+
+export async function destroyTestDb(testDb: TestDb): Promise<void> {
+  await deleteApp(testDb.app);
+}
+
+/** Wipe all emulator data between tests via the emulator's REST endpoint. */
+export async function clearEmulator(): Promise<void> {
+  const host = process.env['FIRESTORE_EMULATOR_HOST'];
+  const response = await fetch(
+    `http://${host}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`,
+    { method: 'DELETE' },
+  );
+  if (!response.ok) {
+    throw new Error(`clearEmulator failed: ${response.status} ${await response.text()}`);
+  }
+}

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/keys.unit.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/keys.unit.test.ts
@@ -35,12 +35,12 @@ test('ARTICLE_MARKERS_COLLECTION is the pinned name', () => {
 });
 
 test('markerBody: carries key, default source backfill, and a createdAt sentinel', () => {
-  const body = markerBody('k1');
+  const body = markerBody('k1', 'item-1');
   assert.equal(body['key'], 'k1');
   assert.equal(body['source'], 'backfill');
   assert.ok('createdAt' in body);
 });
 
 test('markerBody: honors an explicit source', () => {
-  assert.equal(markerBody('k1', 'sync')['source'], 'sync');
+  assert.equal(markerBody('k1', 'item-1', 'sync')['source'], 'sync');
 });

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/keys.unit.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/keys.unit.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ARTICLE_MARKERS_COLLECTION, deriveMarkerKeys, markerBody } from '../keys.js';
+
+test('deriveMarkerKeys: itemId only when resolvedId is null', () => {
+  assert.deepEqual(deriveMarkerKeys('item-1', null), ['item-1']);
+});
+
+test('deriveMarkerKeys: itemId only when resolvedId is undefined', () => {
+  assert.deepEqual(deriveMarkerKeys('item-1', undefined), ['item-1']);
+});
+
+test('deriveMarkerKeys: itemId only when resolvedId is blank/whitespace', () => {
+  assert.deepEqual(deriveMarkerKeys('item-1', ''), ['item-1']);
+  assert.deepEqual(deriveMarkerKeys('item-1', '   '), ['item-1']);
+});
+
+test('deriveMarkerKeys: itemId only when resolvedId equals itemId', () => {
+  assert.deepEqual(deriveMarkerKeys('item-1', 'item-1'), ['item-1']);
+});
+
+test('deriveMarkerKeys: both keys when resolvedId is distinct', () => {
+  assert.deepEqual(deriveMarkerKeys('item-1', 'resolved-9'), ['item-1', 'resolved-9']);
+});
+
+test('deriveMarkerKeys: raw resolvedId value is preserved (Android parity)', () => {
+  // Non-blank but surrounded by whitespace: kept verbatim, matching the Kotlin
+  // markerKeysFor which pushes the raw value.
+  assert.deepEqual(deriveMarkerKeys('item-1', ' resolved-9 '), ['item-1', ' resolved-9 ']);
+});
+
+test('ARTICLE_MARKERS_COLLECTION is the pinned name', () => {
+  assert.equal(ARTICLE_MARKERS_COLLECTION, 'articleMarkers');
+});
+
+test('markerBody: carries key, default source backfill, and a createdAt sentinel', () => {
+  const body = markerBody('k1');
+  assert.equal(body['key'], 'k1');
+  assert.equal(body['source'], 'backfill');
+  assert.ok('createdAt' in body);
+});
+
+test('markerBody: honors an explicit source', () => {
+  assert.equal(markerBody('k1', 'sync')['source'], 'sync');
+});

--- a/warg/cloud-functions/backfill-scripts/src/__tests__/marker-backfill.int.test.ts
+++ b/warg/cloud-functions/backfill-scripts/src/__tests__/marker-backfill.int.test.ts
@@ -1,0 +1,105 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { markersCollection, userArticlesCollection } from '../articles.js';
+import { backfillMarkers } from '../marker-backfill.js';
+import { clearEmulator, createTestDb, destroyTestDb } from './emulator.js';
+import type { TestDb } from './emulator.js';
+
+const USER = 'TEST_USER';
+
+let testDb: TestDb;
+let db: Firestore;
+
+beforeAll(() => {
+  testDb = createTestDb();
+  db = testDb.db;
+});
+
+afterAll(async () => {
+  await destroyTestDb(testDb);
+});
+
+afterEach(async () => {
+  await clearEmulator();
+});
+
+async function seedArticle(
+  itemId: string,
+  fields: Record<string, unknown> = {},
+): Promise<void> {
+  await userArticlesCollection(db, USER).doc(itemId).set({ itemId, ...fields });
+}
+
+async function markerIds(): Promise<string[]> {
+  const snapshot = await markersCollection(db, USER).get();
+  return snapshot.docs.map((doc) => doc.id).sort();
+}
+
+describe('marker backfill (emulator)', () => {
+  it('writes a marker for every derived key (itemId + distinct resolvedId)', async () => {
+    await seedArticle('a1'); // itemId only
+    await seedArticle('a2', { resolvedId: 'r2' }); // both keys
+    await seedArticle('a3', { resolvedId: 'a3' }); // resolvedId == itemId -> itemId only
+
+    const result = await backfillMarkers(db, {
+      user: USER,
+      apply: true,
+      limit: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.articles).toBe(3);
+    expect(result.written).toBe(4); // a1, a2, r2, a3
+    expect(result.errors).toBe(0);
+    expect(await markerIds()).toEqual(['a1', 'a2', 'a3', 'r2']);
+  });
+
+  it('is idempotent: a second run writes nothing', async () => {
+    await seedArticle('a1', { resolvedId: 'r1' });
+    await backfillMarkers(db, { user: USER, apply: true, limit: Number.POSITIVE_INFINITY });
+
+    const second = await backfillMarkers(db, {
+      user: USER,
+      apply: true,
+      limit: Number.POSITIVE_INFINITY,
+    });
+
+    expect(second.written).toBe(0);
+    expect(second.alreadyPresent).toBe(2); // a1, r1
+  });
+
+  it('preserves an existing marker source/createdAt (no clobber)', async () => {
+    await seedArticle('a1');
+    await markersCollection(db, USER).doc('a1').set({
+      key: 'a1',
+      source: 'sync',
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+    });
+
+    const result = await backfillMarkers(db, {
+      user: USER,
+      apply: true,
+      limit: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.alreadyPresent).toBe(1);
+    expect(result.written).toBe(0);
+
+    const marker = await markersCollection(db, USER).doc('a1').get();
+    expect(marker.get('source')).toBe('sync'); // not overwritten to "backfill"
+  });
+
+  it('dry-run reports wouldWrite without writing anything', async () => {
+    await seedArticle('a1', { resolvedId: 'r1' });
+
+    const result = await backfillMarkers(db, {
+      user: USER,
+      apply: false,
+      limit: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.wouldWrite).toBe(2);
+    expect(result.written).toBe(0);
+    expect(await markerIds()).toEqual([]);
+  });
+});

--- a/warg/cloud-functions/backfill-scripts/src/articles.ts
+++ b/warg/cloud-functions/backfill-scripts/src/articles.ts
@@ -1,0 +1,91 @@
+import { FieldPath } from 'firebase-admin/firestore';
+import type {
+  CollectionReference,
+  DocumentData,
+  Firestore,
+  QueryDocumentSnapshot,
+} from 'firebase-admin/firestore';
+
+import { ARTICLE_MARKERS_COLLECTION } from './keys.js';
+
+const USERS_COLLECTION = 'users';
+const ARTICLES_COLLECTION = 'articles';
+
+/** `users/{uid}/articles` — the per-user article collection. */
+export function userArticlesCollection(
+  db: Firestore,
+  uid: string,
+): CollectionReference<DocumentData> {
+  return db.collection(USERS_COLLECTION).doc(uid).collection(ARTICLES_COLLECTION);
+}
+
+/** `users/{uid}/articleMarkers` — the per-user existence-marker collection. */
+export function markersCollection(
+  db: Firestore,
+  uid: string,
+): CollectionReference<DocumentData> {
+  return db
+    .collection(USERS_COLLECTION)
+    .doc(uid)
+    .collection(ARTICLE_MARKERS_COLLECTION);
+}
+
+/** Read the article doc's `resolvedId` field as a raw string (or undefined). */
+export function extractResolvedId(data: DocumentData): string | undefined {
+  const raw = data['resolvedId'];
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+/**
+ * Page through `users/{uid}/articles` ordered by document id, yielding each
+ * snapshot. Single-user per-collection paging is intentional: a
+ * `collectionGroup('articles')` iterator would also sweep the root `articles`
+ * dedup index, whose docs have no parent user.
+ */
+export async function* streamUserArticles(
+  db: Firestore,
+  uid: string,
+  pageSize = 250,
+): AsyncGenerator<QueryDocumentSnapshot<DocumentData>> {
+  const collection = userArticlesCollection(db, uid);
+  let cursor: string | null = null;
+
+  for (;;) {
+    let query = collection.orderBy(FieldPath.documentId()).limit(pageSize);
+    if (cursor) query = query.startAfter(cursor);
+
+    const snapshot = await query.get();
+    if (snapshot.empty) break;
+
+    for (const doc of snapshot.docs) yield doc;
+
+    if (snapshot.docs.length < pageSize) break;
+    cursor = snapshot.docs[snapshot.docs.length - 1]!.id;
+  }
+}
+
+/** Read the user's existing marker doc ids into a Set (one paged scan). */
+export async function readExistingMarkerKeys(
+  db: Firestore,
+  uid: string,
+): Promise<Set<string>> {
+  const collection = markersCollection(db, uid);
+  const keys = new Set<string>();
+  const pageSize = 500;
+  let cursor: string | null = null;
+
+  for (;;) {
+    let query = collection.orderBy(FieldPath.documentId()).limit(pageSize);
+    if (cursor) query = query.startAfter(cursor);
+
+    const snapshot = await query.get();
+    if (snapshot.empty) break;
+
+    for (const doc of snapshot.docs) keys.add(doc.id);
+
+    if (snapshot.docs.length < pageSize) break;
+    cursor = snapshot.docs[snapshot.docs.length - 1]!.id;
+  }
+
+  return keys;
+}

--- a/warg/cloud-functions/backfill-scripts/src/classify.ts
+++ b/warg/cloud-functions/backfill-scripts/src/classify.ts
@@ -1,0 +1,35 @@
+export type DebugLogClass = 'legacy-flat' | 'owner-parent' | 'unknown';
+
+export interface DebugLogDoc {
+  readonly id: string;
+  readonly data: Record<string, unknown> | undefined;
+  readonly hasSessionsSubcollection: boolean;
+}
+
+/**
+ * Classify a top-level `debug_logs/{id}` document for cleanup.
+ *
+ * - `owner-parent` — has a `sessions` subcollection. This is a uid parent of the
+ *   migrated `debug_logs/{uid}/sessions/*` layout and is NEVER deleted. The
+ *   subcollection check is decisive even if the parent doc happens to carry
+ *   flat-shaped fields.
+ * - `legacy-flat` — the old flat session doc shape (`events[]` array +
+ *   `sessionId` string + a `device` field) AND no `sessions` subcollection.
+ *   This is the only class the cleanup ever deletes.
+ * - `unknown` — anything else (missing doc, partial shape). Skipped.
+ */
+export function classifyDebugLogDoc(doc: DebugLogDoc): DebugLogClass {
+  if (doc.hasSessionsSubcollection) return 'owner-parent';
+
+  const data = doc.data;
+  if (
+    data !== undefined &&
+    Array.isArray(data['events']) &&
+    typeof data['sessionId'] === 'string' &&
+    data['device'] != null
+  ) {
+    return 'legacy-flat';
+  }
+
+  return 'unknown';
+}

--- a/warg/cloud-functions/backfill-scripts/src/coverage-gate.ts
+++ b/warg/cloud-functions/backfill-scripts/src/coverage-gate.ts
@@ -41,6 +41,14 @@ export async function computeUserCoverage(
 
 async function main(): Promise<void> {
   const args = parseArgs();
+  if (Number.isFinite(args.limit)) {
+    process.stderr.write(
+      '[gate] ERROR: --limit is not allowed on the coverage gate. ' +
+        'The gate must always scan the full article set to be a valid safety precondition. ' +
+        'Remove --limit and re-run.\n',
+    );
+    process.exit(1);
+  }
   const db = getDb();
 
   const result = await computeUserCoverage(db, args.user, args.limit);

--- a/warg/cloud-functions/backfill-scripts/src/coverage-gate.ts
+++ b/warg/cloud-functions/backfill-scripts/src/coverage-gate.ts
@@ -1,0 +1,65 @@
+import process from 'node:process';
+
+import type { Firestore } from 'firebase-admin/firestore';
+
+import {
+  extractResolvedId,
+  readExistingMarkerKeys,
+  streamUserArticles,
+} from './articles.js';
+import { computeCoverage } from './coverage.js';
+import type { CoverageResult } from './coverage.js';
+import { getDb, isMain, parseArgs } from './firebase.js';
+import { deriveMarkerKeys } from './keys.js';
+
+const MISSING_SAMPLE_SIZE = 20;
+
+/**
+ * Derive the full expected-key set from the user's articles and compare against
+ * their existing markers. Read-only — the authorizing precondition for the
+ * read-rule flip.
+ */
+export async function computeUserCoverage(
+  db: Firestore,
+  user: string,
+  limit = Number.POSITIVE_INFINITY,
+): Promise<CoverageResult> {
+  const existing = await readExistingMarkerKeys(db, user);
+  const expected = new Set<string>();
+
+  let articles = 0;
+  for await (const doc of streamUserArticles(db, user)) {
+    if (articles >= limit) break;
+    articles += 1;
+    for (const key of deriveMarkerKeys(doc.id, extractResolvedId(doc.data()))) {
+      expected.add(key);
+    }
+  }
+
+  return computeCoverage(expected, existing);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const db = getDb();
+
+  const result = await computeUserCoverage(db, args.user, args.limit);
+
+  console.log(
+    `[gate] user=${args.user} expected=${result.expectedCount} existing=${result.existingCount} missing=${result.missing.length}`,
+  );
+  if (result.missing.length > 0) {
+    const sample = result.missing.slice(0, MISSING_SAMPLE_SIZE);
+    console.log(`[gate] sample missing keys: ${sample.join(', ')}`);
+  }
+  console.log(`[gate] ${result.covered ? 'COVERED — safe to flip the read rule' : 'GAP — do NOT flip the read rule'}`);
+
+  process.exit(result.covered ? 0 : 1);
+}
+
+if (isMain(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/warg/cloud-functions/backfill-scripts/src/coverage.ts
+++ b/warg/cloud-functions/backfill-scripts/src/coverage.ts
@@ -1,0 +1,27 @@
+export interface CoverageResult {
+  readonly expectedCount: number;
+  readonly existingCount: number;
+  readonly missing: string[];
+  readonly covered: boolean;
+}
+
+/**
+ * Exact per-user coverage: every expected marker key must have an existing
+ * marker. Extra existing markers (e.g. for keys beyond a `--limit` sample, or
+ * historical keys) do not affect `covered`.
+ */
+export function computeCoverage(
+  expected: ReadonlySet<string>,
+  existing: ReadonlySet<string>,
+): CoverageResult {
+  const missing: string[] = [];
+  for (const key of expected) {
+    if (!existing.has(key)) missing.push(key);
+  }
+  return {
+    expectedCount: expected.size,
+    existingCount: existing.size,
+    missing,
+    covered: missing.length === 0,
+  };
+}

--- a/warg/cloud-functions/backfill-scripts/src/debug-logs-cleanup.ts
+++ b/warg/cloud-functions/backfill-scripts/src/debug-logs-cleanup.ts
@@ -47,29 +47,42 @@ export async function cleanupDebugLogs(
   const sampleLegacyIds: string[] = [];
   const legacyRefs: DocumentReference[] = [];
 
-  for (const ref of refs) {
-    if (scanned >= limit) break;
-    scanned += 1;
+  const CONCURRENCY = 20;
+  const refsToScan = refs.slice(0, limit);
 
-    const [snapshot, subcollections] = await Promise.all([
-      ref.get(),
-      ref.listCollections(),
-    ]);
-    const hasSessions = subcollections.some((c) => c.id === SESSIONS_SUBCOLLECTION);
+  // Fan out classification reads with bounded concurrency (CONCURRENCY docs in
+  // flight at once) so the scan is not a strict sequential RTT waterfall.
+  // Safety guards (legacy-flat-only delete, dry-run default) are unchanged —
+  // they operate on the collected legacyRefs after all reads complete.
+  for (let i = 0; i < refsToScan.length; i += CONCURRENCY) {
+    const batch = refsToScan.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      batch.map(async (ref) => {
+        const [snapshot, subcollections] = await Promise.all([
+          ref.get(),
+          ref.listCollections(),
+        ]);
+        return { ref, snapshot, subcollections };
+      }),
+    );
 
-    const cls = classifyDebugLogDoc({
-      id: ref.id,
-      data: snapshot.exists ? snapshot.data() : undefined,
-      hasSessionsSubcollection: hasSessions,
-    });
+    for (const { ref, snapshot, subcollections } of results) {
+      scanned += 1;
+      const hasSessions = subcollections.some((c) => c.id === SESSIONS_SUBCOLLECTION);
+      const cls = classifyDebugLogDoc({
+        id: ref.id,
+        data: snapshot.exists ? snapshot.data() : undefined,
+        hasSessionsSubcollection: hasSessions,
+      });
 
-    if (cls === 'legacy-flat') {
-      legacyRefs.push(ref);
-      if (sampleLegacyIds.length < 10) sampleLegacyIds.push(ref.id);
-    } else if (cls === 'owner-parent') {
-      ownerParent += 1;
-    } else {
-      unknown += 1;
+      if (cls === 'legacy-flat') {
+        legacyRefs.push(ref);
+        if (sampleLegacyIds.length < 10) sampleLegacyIds.push(ref.id);
+      } else if (cls === 'owner-parent') {
+        ownerParent += 1;
+      } else {
+        unknown += 1;
+      }
     }
   }
 

--- a/warg/cloud-functions/backfill-scripts/src/debug-logs-cleanup.ts
+++ b/warg/cloud-functions/backfill-scripts/src/debug-logs-cleanup.ts
@@ -1,0 +1,129 @@
+import process from 'node:process';
+
+import type { DocumentReference, Firestore } from 'firebase-admin/firestore';
+
+import { classifyDebugLogDoc } from './classify.js';
+import { assertTargetEnv, getDb, isMain, parseArgs } from './firebase.js';
+
+const DEBUG_LOGS_COLLECTION = 'debug_logs';
+const SESSIONS_SUBCOLLECTION = 'sessions';
+
+export interface CleanupOptions {
+  readonly apply: boolean;
+  readonly limit: number;
+}
+
+export interface CleanupResult {
+  readonly scanned: number;
+  readonly legacyFlat: number;
+  readonly ownerParent: number;
+  readonly unknown: number;
+  readonly deleted: number;
+  readonly errors: number;
+  readonly sampleLegacyIds: string[];
+  readonly apply: boolean;
+}
+
+/**
+ * Delete legacy flat `debug_logs/{id}` docs left unreadable after the uid-scoped
+ * migration. A doc is deleted only when it classifies as `legacy-flat`: the old
+ * flat shape AND no `sessions` subcollection. `listDocuments()` surfaces
+ * "missing" parents (a uid with only a `sessions` subcollection) so they are
+ * seen and preserved as `owner-parent`. Deletion uses `recursiveDelete` to
+ * sweep any stray subcollection under a legacy doc.
+ */
+export async function cleanupDebugLogs(
+  db: Firestore,
+  options: CleanupOptions,
+): Promise<CleanupResult> {
+  const { apply, limit } = options;
+  const refs = await db.collection(DEBUG_LOGS_COLLECTION).listDocuments();
+
+  let scanned = 0;
+  let ownerParent = 0;
+  let unknown = 0;
+  let deleted = 0;
+  let errors = 0;
+  const sampleLegacyIds: string[] = [];
+  const legacyRefs: DocumentReference[] = [];
+
+  for (const ref of refs) {
+    if (scanned >= limit) break;
+    scanned += 1;
+
+    const [snapshot, subcollections] = await Promise.all([
+      ref.get(),
+      ref.listCollections(),
+    ]);
+    const hasSessions = subcollections.some((c) => c.id === SESSIONS_SUBCOLLECTION);
+
+    const cls = classifyDebugLogDoc({
+      id: ref.id,
+      data: snapshot.exists ? snapshot.data() : undefined,
+      hasSessionsSubcollection: hasSessions,
+    });
+
+    if (cls === 'legacy-flat') {
+      legacyRefs.push(ref);
+      if (sampleLegacyIds.length < 10) sampleLegacyIds.push(ref.id);
+    } else if (cls === 'owner-parent') {
+      ownerParent += 1;
+    } else {
+      unknown += 1;
+    }
+  }
+
+  if (apply) {
+    for (const ref of legacyRefs) {
+      try {
+        await db.recursiveDelete(ref);
+        deleted += 1;
+        process.stderr.write(`  deleted ${ref.id} (${deleted}/${legacyRefs.length})\n`);
+      } catch (error) {
+        errors += 1;
+        console.error(
+          `[cleanup] failed to delete ${ref.id}: ${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
+  return {
+    scanned,
+    legacyFlat: legacyRefs.length,
+    ownerParent,
+    unknown,
+    deleted,
+    errors,
+    sampleLegacyIds,
+    apply,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  await assertTargetEnv(args.yes);
+  const db = getDb();
+
+  const result = await cleanupDebugLogs(db, { apply: args.apply, limit: args.limit });
+
+  console.log(
+    `[cleanup] mode=${args.apply ? 'APPLY' : 'dry-run'} scanned=${result.scanned} legacyFlat=${result.legacyFlat} ownerParent=${result.ownerParent} unknown=${result.unknown}`,
+  );
+  if (result.sampleLegacyIds.length > 0) {
+    console.log(`[cleanup] sample legacy ids: ${result.sampleLegacyIds.join(', ')}`);
+  }
+  if (args.apply) {
+    console.log(`[cleanup] deleted=${result.deleted} errors=${result.errors}`);
+  } else {
+    console.log('[cleanup] dry-run — pass --apply to delete the legacy-flat docs.');
+  }
+  if (result.errors > 0) process.exitCode = 1;
+}
+
+if (isMain(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/warg/cloud-functions/backfill-scripts/src/firebase.ts
+++ b/warg/cloud-functions/backfill-scripts/src/firebase.ts
@@ -1,0 +1,101 @@
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
+
+/**
+ * The single real production user. The other ~4 accounts are test users that
+ * rely on the app's steady-state marker write + read-denial self-heal once the
+ * tightened read rule deploys. Mirrors `BACKFILL_USER_ID` in backfill-archiver.
+ */
+export const DEFAULT_USER_ID = 'TGtRF6GrQaSmfjGk9GEYJ8YZc0v1';
+
+/** Production Firestore project these scripts target via ADC. */
+export const PROJECT_ID = 'trails-e428e';
+
+/** Abort window before any write/delete against production. */
+const PROD_ABORT_MS = 5_000;
+
+export interface CliArgs {
+  readonly user: string;
+  readonly apply: boolean;
+  readonly limit: number;
+  readonly yes: boolean;
+}
+
+function readFlagValue(argv: readonly string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return argv[idx + 1];
+}
+
+/**
+ * Parse the shared CLI surface. Dry-run is the default; `--apply` opts into
+ * writes/deletes. `--user` overrides the target uid; `--limit` caps the article
+ * scan; `--yes` skips the production abort window.
+ */
+export function parseArgs(argv: readonly string[] = process.argv.slice(2)): CliArgs {
+  const apply = argv.includes('--apply');
+  const yes = argv.includes('--yes');
+  const user = readFlagValue(argv, '--user') ?? DEFAULT_USER_ID;
+
+  let limit = Number.POSITIVE_INFINITY;
+  const limitRaw = readFlagValue(argv, '--limit');
+  if (limitRaw !== undefined) {
+    const parsed = Number(limitRaw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--limit must be a positive number, got "${limitRaw}"`);
+    }
+    limit = Math.floor(parsed);
+  }
+
+  return { user, apply, limit, yes };
+}
+
+/** Lazily initialize the Admin SDK (ADC, or the emulator when
+ * `FIRESTORE_EMULATOR_HOST` is set) and return Firestore. Kept lazy so importing
+ * a CLI module for its exported logic never touches credentials. */
+export function getDb(): Firestore {
+  if (getApps().length === 0) {
+    initializeApp();
+  }
+  return getFirestore();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Make the write target explicit before any destructive operation. When the
+ * emulator host is set we proceed immediately; against production we warn and
+ * wait a short abort window (skippable with `--yes`).
+ */
+export async function assertTargetEnv(skipWait = false): Promise<void> {
+  const emulator = process.env['FIRESTORE_EMULATOR_HOST'];
+  if (emulator) {
+    console.log(`[backfill-scripts] targeting EMULATOR ${emulator}`);
+    return;
+  }
+
+  console.warn(
+    `[backfill-scripts] targeting PRODUCTION ${PROJECT_ID} — press Ctrl-C now to abort.`,
+  );
+  if (skipWait) return;
+
+  for (let remaining = PROD_ABORT_MS / 1_000; remaining > 0; remaining -= 1) {
+    process.stderr.write(`  continuing in ${remaining}s...\r`);
+    await sleep(1_000);
+  }
+  process.stderr.write('\n');
+}
+
+/** True when `moduleUrl` is the entrypoint Node was invoked with. Lets a CLI
+ * file export its logic for tests yet still run `main()` when executed directly. */
+export function isMain(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return moduleUrl === pathToFileURL(entry).href;
+}

--- a/warg/cloud-functions/backfill-scripts/src/firebase.ts
+++ b/warg/cloud-functions/backfill-scripts/src/firebase.ts
@@ -5,13 +5,6 @@ import { getApps, initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import type { Firestore } from 'firebase-admin/firestore';
 
-/**
- * The single real production user. The other ~4 accounts are test users that
- * rely on the app's steady-state marker write + read-denial self-heal once the
- * tightened read rule deploys. Mirrors `BACKFILL_USER_ID` in backfill-archiver.
- */
-export const DEFAULT_USER_ID = 'TGtRF6GrQaSmfjGk9GEYJ8YZc0v1';
-
 /** Production Firestore project these scripts target via ADC. */
 export const PROJECT_ID = 'trails-e428e';
 
@@ -39,7 +32,11 @@ function readFlagValue(argv: readonly string[], flag: string): string | undefine
 export function parseArgs(argv: readonly string[] = process.argv.slice(2)): CliArgs {
   const apply = argv.includes('--apply');
   const yes = argv.includes('--yes');
-  const user = readFlagValue(argv, '--user') ?? DEFAULT_USER_ID;
+  const userFlag = readFlagValue(argv, '--user');
+  const user = userFlag ?? process.env['BACKFILL_USER_ID'];
+  if (!user) {
+    throw new Error('set --user or BACKFILL_USER_ID; refusing to guess the target user');
+  }
 
   let limit = Number.POSITIVE_INFINITY;
   const limitRaw = readFlagValue(argv, '--limit');

--- a/warg/cloud-functions/backfill-scripts/src/firebase.ts
+++ b/warg/cloud-functions/backfill-scripts/src/firebase.ts
@@ -59,7 +59,11 @@ export function parseArgs(argv: readonly string[] = process.argv.slice(2)): CliA
  * a CLI module for its exported logic never touches credentials. */
 export function getDb(): Firestore {
   if (getApps().length === 0) {
-    initializeApp();
+    // Pin the production project so the script can never silently target
+    // whatever project ambient ADC resolves to. The emulator path keeps default
+    // resolution — FIRESTORE_EMULATOR_HOST routes the SDK to the emulator.
+    const usingEmulator = process.env['FIRESTORE_EMULATOR_HOST'] != null;
+    initializeApp(usingEmulator ? undefined : { projectId: PROJECT_ID });
   }
   return getFirestore();
 }

--- a/warg/cloud-functions/backfill-scripts/src/keys.ts
+++ b/warg/cloud-functions/backfill-scripts/src/keys.ts
@@ -1,0 +1,49 @@
+import { FieldValue } from 'firebase-admin/firestore';
+
+/**
+ * Marker subcollection name. Single source of truth shared with the Android
+ * writer (`FirestoreBackupService.ARTICLE_MARKERS_COLLECTION`) and the rules.
+ * Asserted cross-stack by `shared-types/check-drift.ts`.
+ */
+export const ARTICLE_MARKERS_COLLECTION = 'articleMarkers';
+
+/** Provenance recorded on markers this package writes. */
+export const MARKER_SOURCE = 'backfill';
+
+/**
+ * Marker doc keys for an article — a faithful port of the Android
+ * `FirestoreBackupService.markerKeysFor`: the `itemId` always, plus the
+ * `resolvedId` only when it is non-blank and distinct from `itemId`.
+ *
+ * The raw `resolvedId` value is used as the key (not a trimmed/canonicalized
+ * form) so the marker doc ids are byte-identical to what the Android sync path
+ * writes — parity here is load-bearing, since a divergent key would leave an
+ * article unreadable after the read-rule flip.
+ */
+export function deriveMarkerKeys(
+  itemId: string,
+  resolvedId: string | null | undefined,
+): string[] {
+  const keys = [itemId];
+  if (resolvedId != null && resolvedId.trim().length > 0 && resolvedId !== itemId) {
+    keys.push(resolvedId);
+  }
+  return keys;
+}
+
+/**
+ * Minimal marker body. The read rule only checks existence; the fields aid
+ * backfill idempotency, coverage audit, and the drift check. Merge-written, so
+ * re-running never clobbers an existing marker's original `source`/`createdAt`
+ * when the caller skips already-present keys.
+ */
+export function markerBody(
+  key: string,
+  source: string = MARKER_SOURCE,
+): Record<string, unknown> {
+  return {
+    key,
+    createdAt: FieldValue.serverTimestamp(),
+    source,
+  };
+}

--- a/warg/cloud-functions/backfill-scripts/src/keys.ts
+++ b/warg/cloud-functions/backfill-scripts/src/keys.ts
@@ -36,13 +36,20 @@ export function deriveMarkerKeys(
  * backfill idempotency, coverage audit, and the drift check. Merge-written, so
  * re-running never clobbers an existing marker's original `source`/`createdAt`
  * when the caller skips already-present keys.
+ *
+ * `itemId` is the doc id of the owning article at users/{uid}/articles/{itemId}.
+ * Both the itemId-keyed and the resolvedId-keyed marker for the same article
+ * carry the same `itemId` — required for schema uniformity. The Admin SDK
+ * bypasses Firestore security rules, so this field is for schema parity only.
  */
 export function markerBody(
   key: string,
+  itemId: string,
   source: string = MARKER_SOURCE,
 ): Record<string, unknown> {
   return {
     key,
+    itemId,
     createdAt: FieldValue.serverTimestamp(),
     source,
   };

--- a/warg/cloud-functions/backfill-scripts/src/marker-backfill.ts
+++ b/warg/cloud-functions/backfill-scripts/src/marker-backfill.ts
@@ -1,0 +1,152 @@
+import process from 'node:process';
+
+import type { Firestore } from 'firebase-admin/firestore';
+
+import {
+  extractResolvedId,
+  markersCollection,
+  readExistingMarkerKeys,
+  streamUserArticles,
+} from './articles.js';
+import { assertTargetEnv, getDb, isMain, parseArgs } from './firebase.js';
+import { deriveMarkerKeys, markerBody } from './keys.js';
+
+export interface BackfillOptions {
+  readonly user: string;
+  readonly apply: boolean;
+  readonly limit: number;
+  readonly pageSize?: number;
+}
+
+export interface BackfillResult {
+  readonly articles: number;
+  /** Total marker keys derived across all scanned articles. */
+  readonly expectedKeys: number;
+  /** Keys that already had a marker (skipped — never re-written or clobbered). */
+  readonly alreadyPresent: number;
+  /** Markers enqueued and confirmed written (`--apply` only). */
+  readonly written: number;
+  /** Missing markers that would be written (dry-run only). */
+  readonly wouldWrite: number;
+  readonly errors: number;
+  readonly sampleKeys: string[];
+  readonly apply: boolean;
+}
+
+/**
+ * Write a marker for every missing key of the target user's articles.
+ *
+ * Reads the user's existing markers once, then writes ONLY missing keys via a
+ * `BulkWriter` (auto-throttle + retry), so existing markers keep their original
+ * `source`/`createdAt`. Never deletes. Dry-run (`apply: false`) counts without
+ * writing.
+ */
+export async function backfillMarkers(
+  db: Firestore,
+  options: BackfillOptions,
+): Promise<BackfillResult> {
+  const { user, apply, limit } = options;
+  const pageSize = options.pageSize ?? 250;
+
+  // `existing` doubles as an in-run dedup set: a resolvedId shared by two
+  // articles is written once, then counted as already-present thereafter.
+  const existing = await readExistingMarkerKeys(db, user);
+  const markers = markersCollection(db, user);
+
+  let articles = 0;
+  let expectedKeys = 0;
+  let alreadyPresent = 0;
+  let toWrite = 0;
+  let errors = 0;
+  const sampleKeys: string[] = [];
+
+  const writer = apply ? db.bulkWriter() : null;
+  if (writer) {
+    // Attach BEFORE enqueuing any op. BulkWriter auto-retries UNAVAILABLE/
+    // ABORTED internally; this decides when to give up and surfaces a count.
+    writer.onWriteError((error) => {
+      if (error.failedAttempts < 10) return true;
+      errors += 1;
+      console.error(
+        `[backfill] write failed (${error.failedAttempts} attempts) ${error.documentRef.path}: ${error.message}`,
+      );
+      return false;
+    });
+  }
+
+  for await (const doc of streamUserArticles(db, user, pageSize)) {
+    if (articles >= limit) break;
+    articles += 1;
+
+    const keys = deriveMarkerKeys(doc.id, extractResolvedId(doc.data()));
+    for (const key of keys) {
+      expectedKeys += 1;
+      if (existing.has(key)) {
+        alreadyPresent += 1;
+        continue;
+      }
+
+      if (sampleKeys.length < 10) sampleKeys.push(key);
+      toWrite += 1;
+      existing.add(key);
+
+      if (writer) {
+        // Merge keeps the write idempotent. onWriteError handles the retry
+        // decision; the per-op `.catch` only absorbs the final rejection so a
+        // give-up does not surface as an unhandled rejection.
+        writer
+          .set(markers.doc(key), markerBody(key), { merge: true })
+          .catch(() => undefined);
+      }
+    }
+  }
+
+  if (writer) {
+    await writer.close();
+  }
+
+  return {
+    articles,
+    expectedKeys,
+    alreadyPresent,
+    written: apply ? toWrite - errors : 0,
+    wouldWrite: apply ? 0 : toWrite,
+    errors,
+    sampleKeys,
+    apply,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  await assertTargetEnv(args.yes);
+  const db = getDb();
+
+  const result = await backfillMarkers(db, {
+    user: args.user,
+    apply: args.apply,
+    limit: args.limit,
+  });
+
+  console.log(`[backfill] user=${args.user} mode=${args.apply ? 'APPLY' : 'dry-run'}`);
+  const counts = args.apply
+    ? `written=${result.written} errors=${result.errors}`
+    : `wouldWrite=${result.wouldWrite}`;
+  console.log(
+    `[backfill] articles=${result.articles} expectedKeys=${result.expectedKeys} alreadyPresent=${result.alreadyPresent} ${counts}`,
+  );
+  if (result.sampleKeys.length > 0) {
+    console.log(`[backfill] sample missing keys: ${result.sampleKeys.join(', ')}`);
+  }
+  if (!args.apply) {
+    console.log('[backfill] dry-run — pass --apply to write the missing markers.');
+  }
+  if (result.errors > 0) process.exitCode = 1;
+}
+
+if (isMain(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/warg/cloud-functions/backfill-scripts/src/marker-backfill.ts
+++ b/warg/cloud-functions/backfill-scripts/src/marker-backfill.ts
@@ -78,7 +78,8 @@ export async function backfillMarkers(
     if (articles >= limit) break;
     articles += 1;
 
-    const keys = deriveMarkerKeys(doc.id, extractResolvedId(doc.data()));
+    const articleItemId = doc.id;
+    const keys = deriveMarkerKeys(articleItemId, extractResolvedId(doc.data()));
     for (const key of keys) {
       expectedKeys += 1;
       if (existing.has(key)) {
@@ -94,8 +95,10 @@ export async function backfillMarkers(
         // Merge keeps the write idempotent. onWriteError handles the retry
         // decision; the per-op `.catch` only absorbs the final rejection so a
         // give-up does not surface as an unhandled rejection.
+        // Both the itemId-keyed and resolvedId-keyed markers carry the same
+        // articleItemId for schema parity (Admin SDK bypasses rules).
         writer
-          .set(markers.doc(key), markerBody(key), { merge: true })
+          .set(markers.doc(key), markerBody(key, articleItemId), { merge: true })
           .catch(() => undefined);
       }
     }

--- a/warg/cloud-functions/backfill-scripts/tsconfig.json
+++ b/warg/cloud-functions/backfill-scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"]
+}

--- a/warg/cloud-functions/backfill-scripts/vitest.integration.config.ts
+++ b/warg/cloud-functions/backfill-scripts/vitest.integration.config.ts
@@ -9,9 +9,8 @@ export default defineConfig({
     // The emulator is shared process-wide; a single fork keeps clearEmulator()
     // between tests from racing parallel workers.
     pool: 'forks',
-    poolOptions: {
-      forks: { singleFork: true },
-    },
+    maxWorkers: 1,
+    isolate: false,
     testTimeout: 30_000,
     hookTimeout: 30_000,
   },

--- a/warg/cloud-functions/backfill-scripts/vitest.integration.config.ts
+++ b/warg/cloud-functions/backfill-scripts/vitest.integration.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Only the emulator-backed integration suites. The pure `*.unit.test.ts`
+    // files run under `node --test` (see the `test` script), not vitest.
+    include: ['src/__tests__/**/*.int.test.ts'],
+    // The emulator is shared process-wide; a single fork keeps clearEmulator()
+    // between tests from racing parallel workers.
+    pool: 'forks',
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/warg/cloud-functions/dashboard-api/package.json
+++ b/warg/cloud-functions/dashboard-api/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.15.0",
-    "firebase-admin": "^13.0.2",
+    "firebase-admin": "^13.10.0",
     "firebase-functions": "^6.3.0"
   },
   "devDependencies": {

--- a/warg/cloud-functions/dashboard-api/package.json
+++ b/warg/cloud-functions/dashboard-api/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "pnpm run build && node --test \"dist/__tests__/*.test.js\"",
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions --project trails-e428e"
   },

--- a/warg/cloud-functions/dashboard-api/src/__tests__/app-signed-url.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/app-signed-url.test.ts
@@ -146,3 +146,32 @@ test('returns 404 for an article the user does not own', async () => {
 
   assert.equal(captured.status, 404);
 });
+
+// anonymous tokens are accepted by the auth middleware; the ownership check is
+// the real gate. A fresh anonymous uid that doesn't own the article gets 404,
+// not a blanket provider-level rejection.
+test('returns 404 for an anonymous uid that does not own the article', async () => {
+  const emptyDb = {
+    collection: (name: string) =>
+      name === 'users'
+        ? {
+            doc: () => ({
+              collection: () => ({
+                doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }),
+              }),
+            }),
+          }
+        : { doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }) },
+  } as unknown as Firestore;
+  const { res, captured } = makeRes();
+
+  await handleAppSignedUrl(
+    makeReq({ itemId: 'item1234', archiveKey: 'readability' }),
+    res,
+    'anon-uid-fresh',
+    emptyDb,
+    async () => 'unused'
+  );
+
+  assert.equal(captured.status, 404);
+});

--- a/warg/cloud-functions/dashboard-api/src/__tests__/app-signed-url.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/app-signed-url.test.ts
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Request, Response } from 'express';
+import type { Firestore } from 'firebase-admin/firestore';
+import { handleAppSignedUrl } from '../app-signed-url.js';
+import type { ArchiveSigner } from '../signed-url-core.js';
+
+function makeReq(query: Record<string, unknown>): Request {
+  return { query } as unknown as Request;
+}
+
+function makeRes() {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    },
+  } as unknown as Response;
+  return { res, captured };
+}
+
+// Owned article whose canonical doc has a successful readability archive.
+function ownedDb(): Firestore {
+  const snap = (data: Record<string, unknown> | undefined) => ({
+    exists: data !== undefined,
+    data: () => data,
+  });
+  const db = {
+    collection(name: string) {
+      if (name === 'users') {
+        return {
+          doc: () => ({
+            collection: () => ({
+              doc: () => ({ get: async () => snap({}) }),
+            }),
+          }),
+        };
+      }
+      return {
+        doc: () => ({
+          get: async () =>
+            snap({
+              archives: {
+                readability: {
+                  status: 'success',
+                  gcs_path: 'gs://htbase-archives-standard/a/read.json',
+                },
+              },
+            }),
+        }),
+      };
+    },
+  };
+  return db as unknown as Firestore;
+}
+
+// Capture console.log for the duration of fn, returning everything logged.
+async function captureLogs(fn: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((a) => String(a)).join(' '));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+test('returns the signed URL to the owner and never logs the URL', async () => {
+  const SIGNED = 'https://signed.example/SECRET-TOKEN-DO-NOT-LOG';
+  const sign: ArchiveSigner = async () => SIGNED;
+  const { res, captured } = makeRes();
+
+  const logs = await captureLogs(() =>
+    handleAppSignedUrl(
+      makeReq({ itemId: 'item1234', archiveKey: 'readability' }),
+      res,
+      'u1',
+      ownedDb(),
+      sign
+    )
+  );
+
+  // The URL reaches the client...
+  const body = captured.body as { url?: string } | undefined;
+  assert.equal(body?.url, SIGNED);
+
+  // ...but is never written to the logs.
+  for (const line of logs) {
+    assert.ok(!line.includes(SIGNED), `log line leaked the signed URL: ${line}`);
+  }
+  // The log line that IS emitted carries the safe identifiers.
+  assert.ok(logs.some((l) => l.includes('item1234') && l.includes('a/read.json')));
+});
+
+test('rejects a malformed query with 400 before any signing', async () => {
+  let signed = false;
+  const sign: ArchiveSigner = async () => {
+    signed = true;
+    return 'should-not-happen';
+  };
+  const { res, captured } = makeRes();
+
+  await handleAppSignedUrl(
+    makeReq({ itemId: 'short', archiveKey: 'readability' }),
+    res,
+    'u1',
+    ownedDb(),
+    sign
+  );
+
+  assert.equal(captured.status, 400);
+  assert.equal(signed, false);
+});
+
+test('returns 404 for an article the user does not own', async () => {
+  const emptyDb = {
+    collection: (name: string) =>
+      name === 'users'
+        ? {
+            doc: () => ({
+              collection: () => ({
+                doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }),
+              }),
+            }),
+          }
+        : { doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }) },
+  } as unknown as Firestore;
+  const { res, captured } = makeRes();
+
+  await handleAppSignedUrl(
+    makeReq({ itemId: 'item1234', archiveKey: 'readability' }),
+    res,
+    'u1',
+    emptyDb,
+    async () => 'unused'
+  );
+
+  assert.equal(captured.status, 404);
+});

--- a/warg/cloud-functions/dashboard-api/src/__tests__/firebase-auth.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/firebase-auth.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Request, Response } from 'express';
+import { verifyFirebaseToken, type IdTokenVerifier } from '../firebase-auth.js';
+
+function makeReq(authorization?: string): Request {
+  const headers: Record<string, string> = {};
+  if (authorization !== undefined) headers['authorization'] = authorization;
+  return { headers } as unknown as Request;
+}
+
+function makeRes() {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    },
+  } as unknown as Response;
+  return { res, captured };
+}
+
+test('hands the uid to next for a valid, non-anonymous token', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const { res, captured } = makeRes();
+  let nextUid: string | undefined;
+
+  await verifyFirebaseToken(makeReq('Bearer good-token'), res, async (uid) => {
+    nextUid = uid;
+  }, verify);
+
+  assert.equal(nextUid, 'u1');
+  assert.equal(captured.status, undefined);
+});
+
+test('rejects an anonymous token with 403 and does not call next', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'anon-1', signInProvider: 'anonymous' });
+  const { res, captured } = makeRes();
+  let nextCalled = false;
+
+  await verifyFirebaseToken(makeReq('Bearer anon-token'), res, async () => {
+    nextCalled = true;
+  }, verify);
+
+  assert.equal(captured.status, 403);
+  assert.equal(nextCalled, false);
+});
+
+test('returns 401 when verification throws', async () => {
+  const verify: IdTokenVerifier = async () => {
+    throw new Error('token expired');
+  };
+  const { res, captured } = makeRes();
+  let nextCalled = false;
+
+  await verifyFirebaseToken(makeReq('Bearer bad-token'), res, async () => {
+    nextCalled = true;
+  }, verify);
+
+  assert.equal(captured.status, 401);
+  assert.equal(nextCalled, false);
+});
+
+test('returns 401 when the Authorization header is missing', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const { res, captured } = makeRes();
+
+  await verifyFirebaseToken(makeReq(), res, async () => {}, verify);
+
+  assert.equal(captured.status, 401);
+});
+
+test('returns 401 when the header is not a Bearer token', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const { res, captured } = makeRes();
+
+  await verifyFirebaseToken(makeReq('Basic abc123'), res, async () => {}, verify);
+
+  assert.equal(captured.status, 401);
+});
+
+test('returns 401 when the bearer token is empty', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const { res, captured } = makeRes();
+
+  await verifyFirebaseToken(makeReq('Bearer    '), res, async () => {}, verify);
+
+  assert.equal(captured.status, 401);
+});

--- a/warg/cloud-functions/dashboard-api/src/__tests__/firebase-auth.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/firebase-auth.test.ts
@@ -24,8 +24,8 @@ function makeRes() {
   return { res, captured };
 }
 
-test('hands the uid to next for a valid, non-anonymous token', async () => {
-  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+test('hands the uid to next for a valid token', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1' });
   const { res, captured } = makeRes();
   let nextUid: string | undefined;
 
@@ -37,17 +37,17 @@ test('hands the uid to next for a valid, non-anonymous token', async () => {
   assert.equal(captured.status, undefined);
 });
 
-test('rejects an anonymous token with 403 and does not call next', async () => {
-  const verify: IdTokenVerifier = async () => ({ uid: 'anon-1', signInProvider: 'anonymous' });
+test('hands the uid to next for a valid anonymous token', async () => {
+  const verify: IdTokenVerifier = async () => ({ uid: 'anon-1' });
   const { res, captured } = makeRes();
-  let nextCalled = false;
+  let nextUid: string | undefined;
 
-  await verifyFirebaseToken(makeReq('Bearer anon-token'), res, async () => {
-    nextCalled = true;
+  await verifyFirebaseToken(makeReq('Bearer anon-token'), res, async (uid) => {
+    nextUid = uid;
   }, verify);
 
-  assert.equal(captured.status, 403);
-  assert.equal(nextCalled, false);
+  assert.equal(nextUid, 'anon-1');
+  assert.equal(captured.status, undefined);
 });
 
 test('returns 401 when verification throws', async () => {
@@ -66,7 +66,7 @@ test('returns 401 when verification throws', async () => {
 });
 
 test('returns 401 when the Authorization header is missing', async () => {
-  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1' });
   const { res, captured } = makeRes();
 
   await verifyFirebaseToken(makeReq(), res, async () => {}, verify);
@@ -75,7 +75,7 @@ test('returns 401 when the Authorization header is missing', async () => {
 });
 
 test('returns 401 when the header is not a Bearer token', async () => {
-  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1' });
   const { res, captured } = makeRes();
 
   await verifyFirebaseToken(makeReq('Basic abc123'), res, async () => {}, verify);
@@ -84,7 +84,7 @@ test('returns 401 when the header is not a Bearer token', async () => {
 });
 
 test('returns 401 when the bearer token is empty', async () => {
-  const verify: IdTokenVerifier = async () => ({ uid: 'u1', signInProvider: 'google.com' });
+  const verify: IdTokenVerifier = async () => ({ uid: 'u1' });
   const { res, captured } = makeRes();
 
   await verifyFirebaseToken(makeReq('Bearer    '), res, async () => {}, verify);

--- a/warg/cloud-functions/dashboard-api/src/__tests__/signed-url-core.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/signed-url-core.test.ts
@@ -202,3 +202,71 @@ test('returns 404 when the requested archive is missing or not successful', asyn
   assert.equal(result.ok, false);
   assert.equal(result.ok === false && result.status, 404);
 });
+
+// M2: gcs_path bucket mismatch should surface as an error (thrown from toObjectPath,
+// propagates as an unhandled rejection — callers will see a thrown error, not a
+// structured result, which is intentional: bucket mismatch is a data-integrity bug).
+test('throws when gcs_path references a different bucket', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': {} },
+    canonical: {
+      'item1234': {
+        archives: {
+          readability: {
+            status: 'success',
+            gcs_path: 'gs://wrong-bucket/a/read.json',
+          },
+        },
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      resolveAndSignArchive({
+        db,
+        ownerUid: 'u1',
+        itemId: 'item1234',
+        archiveKey: 'readability',
+        sign: fakeSign,
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes('bucket mismatch'));
+      return true;
+    }
+  );
+});
+
+// M4: sign() failure should return a structured 502, not propagate.
+test('returns 502 when sign() throws', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': {} },
+    canonical: {
+      'item1234': {
+        archives: {
+          readability: {
+            status: 'success',
+            gcs_path: 'gs://htbase-archives-standard/a/read.json',
+          },
+        },
+      },
+    },
+  });
+
+  const failSign: ArchiveSigner = async () => {
+    throw new Error('IAM signBlob unavailable');
+  };
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: failSign,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.status, 502);
+  assert.equal(result.ok === false && result.error, 'Failed to generate signed URL');
+});

--- a/warg/cloud-functions/dashboard-api/src/__tests__/signed-url-core.test.ts
+++ b/warg/cloud-functions/dashboard-api/src/__tests__/signed-url-core.test.ts
@@ -1,0 +1,204 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Firestore } from 'firebase-admin/firestore';
+import {
+  resolveAndSignArchive,
+  validateSignedUrlQuery,
+  type ArchiveSigner,
+} from '../signed-url-core.js';
+
+// ── Fake Firestore ────────────────────────────────────────────────────────
+// Minimal stand-in that models only the two reads the core performs:
+//   users/{uid}/articles/{itemId}   (ownership + canonical resolution)
+//   articles/{canonicalId}          (the archive map)
+// Keyed by itemId / canonicalId; a missing key models a non-existent doc
+// (i.e. the requesting user does not own the article).
+
+function makeSnap(data: Record<string, unknown> | undefined) {
+  return { exists: data !== undefined, data: () => data };
+}
+
+function makeDb(config: {
+  userArticles: Record<string, Record<string, unknown> | undefined>;
+  canonical: Record<string, Record<string, unknown> | undefined>;
+}): Firestore {
+  const db = {
+    collection(name: string) {
+      if (name === 'users') {
+        return {
+          doc() {
+            return {
+              collection() {
+                return {
+                  doc(itemId: string) {
+                    return { get: async () => makeSnap(config.userArticles[itemId]) };
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+      if (name === 'articles') {
+        return {
+          doc(canonicalId: string) {
+            return { get: async () => makeSnap(config.canonical[canonicalId]) };
+          },
+        };
+      }
+      throw new Error(`unexpected collection: ${name}`);
+    },
+  };
+  // Boundary cast: the fake implements only the slice of Firestore the core uses.
+  return db as unknown as Firestore;
+}
+
+const fakeSign: ArchiveSigner = async (objectPath) =>
+  `https://signed.example/${encodeURIComponent(objectPath)}`;
+
+// ── validateSignedUrlQuery ──────────────────────────────────────────────────
+
+test('validateSignedUrlQuery rejects missing params', () => {
+  const r = validateSignedUrlQuery(undefined, 'readability');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 400);
+});
+
+test('validateSignedUrlQuery rejects non-string params', () => {
+  const r = validateSignedUrlQuery(['item1234'], 'readability');
+  assert.equal(r.ok, false);
+});
+
+test('validateSignedUrlQuery rejects a malformed itemId', () => {
+  const r = validateSignedUrlQuery('short', 'readability');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.error, 'Invalid itemId format');
+});
+
+test('validateSignedUrlQuery rejects an unknown archiveKey', () => {
+  const r = validateSignedUrlQuery('item1234', 'not-a-real-key');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.error, 'Invalid archiveKey');
+});
+
+test('validateSignedUrlQuery accepts a well-formed query', () => {
+  const r = validateSignedUrlQuery('item-1234', 'readability');
+  assert.equal(r.ok, true);
+  assert.equal(r.ok === true && r.itemId, 'item-1234');
+  assert.equal(r.ok === true && r.archiveKey, 'readability');
+});
+
+// ── resolveAndSignArchive ───────────────────────────────────────────────────
+
+test('signs the object for an owned article and resolves the canonical id', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': { resolvedId: 'canon-9' } },
+    canonical: {
+      'canon-9': {
+        archives: {
+          readability: { status: 'success', gcs_path: 'gs://htbase-archives-standard/a/read.json' },
+        },
+      },
+    },
+  });
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: fakeSign,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.body.item_id, 'item1234');
+  assert.equal(result.body.canonical_item_id, 'canon-9');
+  assert.equal(result.body.archive_key, 'readability');
+  assert.equal(result.body.archive_source_key, 'readability');
+  assert.equal(result.objectPath, 'a/read.json');
+  assert.equal(result.body.url, 'https://signed.example/a%2Fread.json');
+});
+
+test('resolves an archive-key alias (readability → readability_json)', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': {} },
+    canonical: {
+      'item1234': {
+        archives: {
+          readability_json: {
+            status: 'success',
+            gcs_path: 'gs://htbase-archives-standard/a/readability.json',
+          },
+        },
+      },
+    },
+  });
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: fakeSign,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.body.archive_source_key, 'readability_json');
+  assert.equal(result.objectPath, 'a/readability.json');
+});
+
+test('returns 404 when the requesting user does not own the article', async () => {
+  const db = makeDb({ userArticles: {}, canonical: {} });
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: fakeSign,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.status, 404);
+  assert.equal(result.ok === false && result.error, 'Article not found');
+});
+
+test('returns 404 when the canonical article is absent', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': { resolvedId: 'canon-9' } },
+    canonical: {},
+  });
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: fakeSign,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.error, 'Canonical article not found');
+});
+
+test('returns 404 when the requested archive is missing or not successful', async () => {
+  const db = makeDb({
+    userArticles: { 'item1234': {} },
+    canonical: {
+      'item1234': { archives: { readability: { status: 'failed' } } },
+    },
+  });
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: 'u1',
+    itemId: 'item1234',
+    archiveKey: 'readability',
+    sign: fakeSign,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.status, 404);
+});

--- a/warg/cloud-functions/dashboard-api/src/app-signed-url.ts
+++ b/warg/cloud-functions/dashboard-api/src/app-signed-url.ts
@@ -1,0 +1,48 @@
+import { getFirestore, type Firestore } from 'firebase-admin/firestore';
+import type { Request, Response } from 'express';
+import {
+  resolveAndSignArchive,
+  validateSignedUrlQuery,
+  type ArchiveSigner,
+} from './signed-url-core.js';
+
+/**
+ * GET /app/signed-url?itemId=X&archiveKey=Y handler (per-user, Firebase-token auth).
+ *
+ * Ownership is the verified token `uid` passed in by the auth middleware — the
+ * signed URL is returned only if that user owns
+ * `users/{uid}/articles/{itemId}`. The full signed URL is NEVER logged: it
+ * grants read access to the object for its TTL, so only the itemId, archiveKey,
+ * and object path are recorded.
+ */
+export async function handleAppSignedUrl(
+  req: Request,
+  res: Response,
+  uid: string,
+  db: Firestore = getFirestore(),
+  sign?: ArchiveSigner
+): Promise<void> {
+  const query = validateSignedUrlQuery(req.query['itemId'], req.query['archiveKey']);
+  if (!query.ok) {
+    res.status(query.status).json({ error: query.error });
+    return;
+  }
+
+  const result = await resolveAndSignArchive({
+    db,
+    ownerUid: uid,
+    itemId: query.itemId,
+    archiveKey: query.archiveKey,
+    sign,
+  });
+
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+
+  console.log(
+    `[app-signed-url] signed itemId=${query.itemId} archiveKey=${query.archiveKey} object=${result.objectPath}`
+  );
+  res.json(result.body);
+}

--- a/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
+++ b/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
@@ -14,23 +14,21 @@ const BEARER_PREFIX = 'Bearer ';
  * safe; the Admin SDK caches the Auth instance and the public signing keys
  * internally, so per-request calls are cheap.
  */
-export type IdTokenVerifier = (
-  token: string
-) => Promise<{ uid: string; signInProvider: string }>;
+export type IdTokenVerifier = (token: string) => Promise<{ uid: string }>;
 
 const defaultVerifier: IdTokenVerifier = async (token) => {
   const decoded = await getAuth().verifyIdToken(token);
-  return { uid: decoded.uid, signInProvider: decoded.firebase.sign_in_provider };
+  return { uid: decoded.uid };
 };
 
 /**
  * Verify a Firebase ID token from the `Authorization: Bearer <token>` header.
  *
  * - Missing/malformed header or unverifiable token → 401.
- * - Anonymous Firebase users (real uid, `sign_in_provider === 'anonymous'`)
- *   are explicitly rejected → 403. Anonymous accounts own no articles, but we
- *   reject before any Firestore work so the signing lane is never reachable by
- *   an unauthenticated identity.
+ * - Anonymous tokens are accepted: anonymous users receive a real uid and can
+ *   own synced articles. Per-user ownership is enforced downstream by the
+ *   handler (users/{uid}/articles/{itemId}), which an attacker's fresh
+ *   anonymous uid cannot satisfy.
  * - Otherwise the decoded uid is handed to `next`.
  */
 export async function verifyFirebaseToken(
@@ -52,22 +50,15 @@ export async function verifyFirebaseToken(
   }
 
   let uid: string;
-  let signInProvider: string;
   try {
     const result = await verify(token);
     uid = result.uid;
-    signInProvider = result.signInProvider;
   } catch (err) {
     console.error(
       '[firebase-auth] verifyIdToken failed:',
       err instanceof Error ? err.message : 'unknown error'
     );
     res.status(401).json({ error: 'Invalid or expired token' });
-    return;
-  }
-
-  if (signInProvider === 'anonymous') {
-    res.status(403).json({ error: 'Anonymous users are not permitted' });
     return;
   }
 

--- a/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
+++ b/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
@@ -1,0 +1,80 @@
+import { getAuth, type Auth } from 'firebase-admin/auth';
+import type { Request, Response } from 'express';
+
+const BEARER_PREFIX = 'Bearer ';
+
+// Lazily instantiate and cache the Auth client. It is NOT created at module
+// scope because route modules are imported before index.ts runs
+// initializeApp(); an eager getAuth() would throw "default app does not
+// exist" at import time. First request (after init) populates the cache, which
+// is then reused for the warm instance's lifetime — the SDK caches the public
+// signing keys separately, so per-request verification stays cheap.
+let cachedAuth: Auth | undefined;
+function auth(): Auth {
+  return (cachedAuth ??= getAuth());
+}
+
+/**
+ * Verifies an ID token and returns the uid + sign-in provider. Injectable so
+ * the middleware can be unit-tested without the Admin SDK or a real token; the
+ * production default delegates to the cached Auth client.
+ */
+export type IdTokenVerifier = (
+  token: string
+) => Promise<{ uid: string; signInProvider: string }>;
+
+const defaultVerifier: IdTokenVerifier = async (token) => {
+  const decoded = await auth().verifyIdToken(token);
+  return { uid: decoded.uid, signInProvider: decoded.firebase.sign_in_provider };
+};
+
+/**
+ * Verify a Firebase ID token from the `Authorization: Bearer <token>` header.
+ *
+ * - Missing/malformed header or unverifiable token → 401.
+ * - Anonymous Firebase users (real uid, `sign_in_provider === 'anonymous'`)
+ *   are explicitly rejected → 403. Anonymous accounts own no articles, but we
+ *   reject before any Firestore work so the signing lane is never reachable by
+ *   an unauthenticated identity.
+ * - Otherwise the decoded uid is handed to `next`.
+ */
+export async function verifyFirebaseToken(
+  req: Request,
+  res: Response,
+  next: (uid: string) => Promise<void>,
+  verify: IdTokenVerifier = defaultVerifier
+): Promise<void> {
+  const header = req.headers['authorization'];
+  if (typeof header !== 'string' || !header.startsWith(BEARER_PREFIX)) {
+    res.status(401).json({ error: 'Missing or malformed Authorization header' });
+    return;
+  }
+
+  const token = header.slice(BEARER_PREFIX.length).trim();
+  if (!token) {
+    res.status(401).json({ error: 'Missing bearer token' });
+    return;
+  }
+
+  let uid: string;
+  let signInProvider: string;
+  try {
+    const result = await verify(token);
+    uid = result.uid;
+    signInProvider = result.signInProvider;
+  } catch (err) {
+    console.error(
+      '[firebase-auth] verifyIdToken failed:',
+      err instanceof Error ? err.message : 'unknown error'
+    );
+    res.status(401).json({ error: 'Invalid or expired token' });
+    return;
+  }
+
+  if (signInProvider === 'anonymous') {
+    res.status(403).json({ error: 'Anonymous users are not permitted' });
+    return;
+  }
+
+  await next(uid);
+}

--- a/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
+++ b/warg/cloud-functions/dashboard-api/src/firebase-auth.ts
@@ -1,30 +1,25 @@
-import { getAuth, type Auth } from 'firebase-admin/auth';
+import { getAuth } from 'firebase-admin/auth';
 import type { Request, Response } from 'express';
 
 const BEARER_PREFIX = 'Bearer ';
 
-// Lazily instantiate and cache the Auth client. It is NOT created at module
-// scope because route modules are imported before index.ts runs
-// initializeApp(); an eager getAuth() would throw "default app does not
-// exist" at import time. First request (after init) populates the cache, which
-// is then reused for the warm instance's lifetime — the SDK caches the public
-// signing keys separately, so per-request verification stays cheap.
-let cachedAuth: Auth | undefined;
-function auth(): Auth {
-  return (cachedAuth ??= getAuth());
-}
-
 /**
  * Verifies an ID token and returns the uid + sign-in provider. Injectable so
  * the middleware can be unit-tested without the Admin SDK or a real token; the
- * production default delegates to the cached Auth client.
+ * production default delegates to the Admin SDK's Auth singleton.
+ *
+ * Note: getAuth() is NOT called at module scope — route modules are imported
+ * before index.ts runs initializeApp(), so an eager call would throw "default
+ * app does not exist". Calling it inside the verifier (at request time) is
+ * safe; the Admin SDK caches the Auth instance and the public signing keys
+ * internally, so per-request calls are cheap.
  */
 export type IdTokenVerifier = (
   token: string
 ) => Promise<{ uid: string; signInProvider: string }>;
 
 const defaultVerifier: IdTokenVerifier = async (token) => {
-  const decoded = await auth().verifyIdToken(token);
+  const decoded = await getAuth().verifyIdToken(token);
   return { uid: decoded.uid, signInProvider: decoded.firebase.sign_in_provider };
 };
 

--- a/warg/cloud-functions/dashboard-api/src/index.ts
+++ b/warg/cloud-functions/dashboard-api/src/index.ts
@@ -25,6 +25,7 @@ if (getApps().length === 0) {
  *   POST /articles/:itemId/bootstrap       → ensure canonical article bootstrap fields
  *   POST /articles/:itemId/mark-processing → set canonical processing state + request id
  *   GET /signed-url         → signed GCS download URL (Milestone 3)
+ *   GET /app/signed-url     → per-user signed GCS download URL (Firebase ID token auth)
  */
 export const dashboardApi = onRequest(
   { cors: true, memory: '1GiB', maxInstances: 20, timeoutSeconds: 120 },

--- a/warg/cloud-functions/dashboard-api/src/index.ts
+++ b/warg/cloud-functions/dashboard-api/src/index.ts
@@ -1,9 +1,11 @@
 import { initializeApp, getApps } from 'firebase-admin/app';
 import { onRequest } from 'firebase-functions/v2/https';
 import { verifyApiKey } from './auth.js';
+import { verifyFirebaseToken } from './firebase-auth.js';
 import { handleListArticles } from './list-articles.js';
 import { handleGetArticle } from './get-article.js';
 import { handleSignedUrl } from './signed-url.js';
+import { handleAppSignedUrl } from './app-signed-url.js';
 import { handleEnqueueArticle } from './enqueue-article.js';
 import { handleBootstrapArticle } from './bootstrap-article.js';
 import { handleMarkProcessing } from './mark-processing.js';
@@ -27,6 +29,21 @@ if (getApps().length === 0) {
 export const dashboardApi = onRequest(
   { cors: true, memory: '1GiB', maxInstances: 20, timeoutSeconds: 120 },
   async (req, res) => {
+    // Per-user signed-URL lane (Firebase ID token, NOT the internal API key).
+    // Matched ahead of the verifyApiKey wrapper so app users never need the
+    // internal key. Only an exact `GET /app/signed-url` lands here; every other
+    // path falls through to the API-key-protected dashboard routes below.
+    const appPath = req.path.replace(/^\/+|\/+$/g, '');
+    if (req.method === 'GET' && appPath === 'app/signed-url') {
+      verifyFirebaseToken(req, res, (uid) => handleAppSignedUrl(req, res, uid)).catch((err) => {
+        console.error('[dashboard-api] Unhandled /app/signed-url error:', err);
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Internal server error' });
+        }
+      });
+      return;
+    }
+
     // Auth middleware
     verifyApiKey(req, res, () => {
       void (async () => {

--- a/warg/cloud-functions/dashboard-api/src/signed-url-core.ts
+++ b/warg/cloud-functions/dashboard-api/src/signed-url-core.ts
@@ -1,0 +1,170 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import { Storage } from '@google-cloud/storage';
+import { ALL_ARCHIVE_KEYS } from './types.js';
+import { resolveCanonicalItemId } from './util.js';
+
+const GCS_BUCKET = process.env['GCS_BUCKET'] || 'htbase-archives-standard';
+const GCS_PROJECT_ID = process.env['GCS_PROJECT_ID'] || 'trails-414917';
+const SIGNED_URL_EXPIRY_MINUTES = 15;
+const ARCHIVE_ALIASES: Partial<Record<string, readonly string[]>> = {
+  readability: ['readability', 'readability_json'],
+  markdown: ['markdown', 'readability_md'],
+};
+
+interface ArchiveRecord {
+  status?: string;
+  gcs_path?: string;
+}
+
+/** Response body returned to the caller — identical for the dashboard and the per-user app route. */
+export interface SignedUrlResponseBody {
+  url: string;
+  expires_at: string;
+  item_id: string;
+  canonical_item_id: string;
+  archive_key: string;
+  archive_source_key: string;
+}
+
+export type ResolveAndSignResult =
+  | { ok: true; body: SignedUrlResponseBody; objectPath: string }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Produces a V4 signed read URL for a GCS object. Injectable so the signing
+ * (the one piece that talks to GCS / the IAM signBlob API) can be replaced in
+ * unit tests without a real bucket or credentials.
+ */
+export type ArchiveSigner = (objectPath: string, expiresAt: Date) => Promise<string>;
+
+const defaultSigner: ArchiveSigner = async (objectPath, expiresAt) => {
+  const storage = new Storage({ projectId: GCS_PROJECT_ID });
+  const file = storage.bucket(GCS_BUCKET).file(objectPath);
+  const [signedUrl] = await file.getSignedUrl({
+    version: 'v4',
+    action: 'read',
+    expires: expiresAt,
+  });
+  return signedUrl;
+};
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]{8,40}$/;
+
+/**
+ * Validate the `itemId` / `archiveKey` query params shared by both signed-URL
+ * routes. Single source of truth for the request contract — boundary input is
+ * `unknown` and narrowed here before any Firestore/GCS work.
+ */
+export function validateSignedUrlQuery(
+  itemId: unknown,
+  archiveKey: unknown
+):
+  | { ok: true; itemId: string; archiveKey: string }
+  | { ok: false; status: number; error: string } {
+  if (typeof itemId !== 'string' || !itemId || typeof archiveKey !== 'string' || !archiveKey) {
+    return { ok: false, status: 400, error: 'Missing required query params: itemId, archiveKey' };
+  }
+  if (!SAFE_ID_RE.test(itemId)) {
+    return { ok: false, status: 400, error: 'Invalid itemId format' };
+  }
+  if (!ALL_ARCHIVE_KEYS.includes(archiveKey as (typeof ALL_ARCHIVE_KEYS)[number])) {
+    return { ok: false, status: 400, error: 'Invalid archiveKey' };
+  }
+  return { ok: true, itemId, archiveKey };
+}
+
+function resolveArchiveWithAlias(
+  archives: Record<string, ArchiveRecord> | undefined,
+  archiveKey: string
+): { sourceKey: string; archive: ArchiveRecord } | undefined {
+  if (!archives) return undefined;
+  const aliases = ARCHIVE_ALIASES[archiveKey] ?? [archiveKey];
+  for (const key of aliases) {
+    const archive = archives[key];
+    if (archive) {
+      return { sourceKey: key, archive };
+    }
+  }
+  return undefined;
+}
+
+/** Strip the gs://bucket-name/ prefix to get the object path within the bucket. */
+function toObjectPath(gcsPath: string): string {
+  if (!gcsPath.startsWith('gs://')) return gcsPath;
+  const withoutScheme = gcsPath.slice(5);
+  const slashIdx = withoutScheme.indexOf('/');
+  return slashIdx >= 0 ? withoutScheme.slice(slashIdx + 1) : withoutScheme;
+}
+
+/**
+ * Shared signing core for both signed-URL routes.
+ *
+ * Proves ownership by reading `users/{ownerUid}/articles/{itemId}` (which also
+ * yields the canonical id), resolves the requested archive (with key aliases),
+ * and returns a short-lived V4 signed read URL for the GCS object. The two
+ * route wrappers differ only in how `ownerUid` is obtained (a hardcoded
+ * dashboard user vs. the verified Firebase token uid); the signing, resolution,
+ * and validation contract live here exactly once.
+ *
+ * `itemId` and `archiveKey` must already be format-validated by the caller.
+ */
+export async function resolveAndSignArchive(params: {
+  db: Firestore;
+  ownerUid: string;
+  itemId: string;
+  archiveKey: string;
+  sign?: ArchiveSigner;
+}): Promise<ResolveAndSignResult> {
+  const { db, ownerUid, itemId, archiveKey, sign = defaultSigner } = params;
+
+  const userSnap = await db
+    .collection('users')
+    .doc(ownerUid)
+    .collection('articles')
+    .doc(itemId)
+    .get();
+
+  if (!userSnap.exists) {
+    return { ok: false, status: 404, error: 'Article not found' };
+  }
+
+  const canonicalItemId = resolveCanonicalItemId(
+    itemId,
+    userSnap.data() as Record<string, unknown>
+  );
+  const docSnap = await db.collection('articles').doc(canonicalItemId).get();
+
+  if (!docSnap.exists) {
+    return { ok: false, status: 404, error: 'Canonical article not found' };
+  }
+
+  const doc = docSnap.data()!;
+  const archives = doc['archives'] as Record<string, ArchiveRecord> | undefined;
+  const resolved = resolveArchiveWithAlias(archives, archiveKey);
+  const archive = resolved?.archive;
+
+  if (!archive || archive.status !== 'success' || !archive.gcs_path) {
+    return {
+      ok: false,
+      status: 404,
+      error: `Archive '${archiveKey}' not available (status: ${archive?.status ?? 'absent'})`,
+    };
+  }
+
+  const objectPath = toObjectPath(archive.gcs_path);
+  const expiresAt = new Date(Date.now() + SIGNED_URL_EXPIRY_MINUTES * 60 * 1000);
+  const signedUrl = await sign(objectPath, expiresAt);
+
+  return {
+    ok: true,
+    objectPath,
+    body: {
+      url: signedUrl,
+      expires_at: expiresAt.toISOString(),
+      item_id: itemId,
+      canonical_item_id: canonicalItemId,
+      archive_key: archiveKey,
+      archive_source_key: resolved?.sourceKey ?? archiveKey,
+    },
+  };
+}

--- a/warg/cloud-functions/dashboard-api/src/signed-url-core.ts
+++ b/warg/cloud-functions/dashboard-api/src/signed-url-core.ts
@@ -6,6 +6,9 @@ import { resolveCanonicalItemId } from './util.js';
 const GCS_BUCKET = process.env['GCS_BUCKET'] || 'htbase-archives-standard';
 const GCS_PROJECT_ID = process.env['GCS_PROJECT_ID'] || 'trails-414917';
 const SIGNED_URL_EXPIRY_MINUTES = 15;
+
+// M5: Single Storage client reused across invocations (not re-created per request).
+const sharedStorage = new Storage({ projectId: GCS_PROJECT_ID });
 const ARCHIVE_ALIASES: Partial<Record<string, readonly string[]>> = {
   readability: ['readability', 'readability_json'],
   markdown: ['markdown', 'readability_md'],
@@ -38,8 +41,7 @@ export type ResolveAndSignResult =
 export type ArchiveSigner = (objectPath: string, expiresAt: Date) => Promise<string>;
 
 const defaultSigner: ArchiveSigner = async (objectPath, expiresAt) => {
-  const storage = new Storage({ projectId: GCS_PROJECT_ID });
-  const file = storage.bucket(GCS_BUCKET).file(objectPath);
+  const file = sharedStorage.bucket(GCS_BUCKET).file(objectPath);
   const [signedUrl] = await file.getSignedUrl({
     version: 'v4',
     action: 'read',
@@ -88,12 +90,31 @@ function resolveArchiveWithAlias(
   return undefined;
 }
 
-/** Strip the gs://bucket-name/ prefix to get the object path within the bucket. */
+/**
+ * Strip the gs://bucket-name/ prefix to get the object path within the bucket.
+ *
+ * CR-2 (cross-stack contract note): this module trims the resolved canonical id
+ * (`resolvedId`) when looking up the top-level articles doc. The backfill script's
+ * `deriveMarkerKeys` preserves the raw value for Android parity — the divergence is
+ * intentional (two separate read paths with different normalization needs) and is NOT
+ * a bug.
+ *
+ * M2 (bucket assertion): if the path includes an explicit bucket segment we verify it
+ * matches the configured GCS_BUCKET so a doc whose gcs_path points at a different
+ * bucket is rejected rather than silently re-routed.
+ */
 function toObjectPath(gcsPath: string): string {
   if (!gcsPath.startsWith('gs://')) return gcsPath;
-  const withoutScheme = gcsPath.slice(5);
+  const withoutScheme = gcsPath.slice(5); // strip "gs://"
   const slashIdx = withoutScheme.indexOf('/');
-  return slashIdx >= 0 ? withoutScheme.slice(slashIdx + 1) : withoutScheme;
+  if (slashIdx < 0) return withoutScheme; // no object path component — pass through as-is
+  const embeddedBucket = withoutScheme.slice(0, slashIdx);
+  if (embeddedBucket !== GCS_BUCKET) {
+    throw new Error(
+      `gcs_path bucket mismatch: expected '${GCS_BUCKET}', got '${embeddedBucket}'`
+    );
+  }
+  return withoutScheme.slice(slashIdx + 1);
 }
 
 /**
@@ -153,7 +174,21 @@ export async function resolveAndSignArchive(params: {
 
   const objectPath = toObjectPath(archive.gcs_path);
   const expiresAt = new Date(Date.now() + SIGNED_URL_EXPIRY_MINUTES * 60 * 1000);
-  const signedUrl = await sign(objectPath, expiresAt);
+
+  // M4: catch IAM / network failures from the GCS sign() call so they produce a
+  // structured 502 rather than propagating to the generic top-level 500 handler.
+  let signedUrl: string;
+  try {
+    signedUrl = await sign(objectPath, expiresAt);
+  } catch (err) {
+    console.error('GCS sign() failed', {
+      objectPath,
+      archiveKey,
+      ownerUid,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { ok: false, status: 502, error: 'Failed to generate signed URL' };
+  }
 
   return {
     ok: true,

--- a/warg/cloud-functions/dashboard-api/src/signed-url.ts
+++ b/warg/cloud-functions/dashboard-api/src/signed-url.ts
@@ -1,130 +1,34 @@
 import { getFirestore } from 'firebase-admin/firestore';
-import { Storage } from '@google-cloud/storage';
 import type { Request, Response } from 'express';
-import { ALL_ARCHIVE_KEYS } from './types.js';
 import { getDashboardUserId } from './config.js';
-import { resolveCanonicalItemId } from './util.js';
-
-const GCS_BUCKET = process.env['GCS_BUCKET'] || 'htbase-archives-standard';
-const GCS_PROJECT_ID = process.env['GCS_PROJECT_ID'] || 'trails-414917';
-const SIGNED_URL_EXPIRY_MINUTES = 15;
-const ARCHIVE_ALIASES: Partial<Record<string, readonly string[]>> = {
-  readability: ['readability', 'readability_json'],
-  markdown: ['markdown', 'readability_md'],
-};
-
-interface ArchiveRecord {
-  status?: string;
-  gcs_path?: string;
-}
-
-function resolveArchiveWithAlias(
-  archives: Record<string, ArchiveRecord> | undefined,
-  archiveKey: string
-): { sourceKey: string; archive: ArchiveRecord } | undefined {
-  if (!archives) return undefined;
-  const aliases = ARCHIVE_ALIASES[archiveKey] ?? [archiveKey];
-  for (const key of aliases) {
-    const archive = archives[key];
-    if (archive) {
-      return { sourceKey: key, archive };
-    }
-  }
-  return undefined;
-}
+import { resolveAndSignArchive, validateSignedUrlQuery } from './signed-url-core.js';
 
 /**
- * GET /signed-url?itemId=X&archiveKey=Y handler.
- * Returns a signed GCS download URL for the specified archive artifact.
+ * GET /signed-url?itemId=X&archiveKey=Y handler (dashboard, API-key auth).
+ * Returns a signed GCS download URL for the specified archive artifact,
+ * scoped to the single hardcoded dashboard user.
  */
 export async function handleSignedUrl(
   req: Request,
   res: Response
 ): Promise<void> {
-  const itemId = req.query['itemId'] as string | undefined;
-  const archiveKey = req.query['archiveKey'] as string | undefined;
-
-  if (!itemId || !archiveKey) {
-    res.status(400).json({ error: 'Missing required query params: itemId, archiveKey' });
+  const query = validateSignedUrlQuery(req.query['itemId'], req.query['archiveKey']);
+  if (!query.ok) {
+    res.status(query.status).json({ error: query.error });
     return;
   }
 
-  const SAFE_ID_RE = /^[a-zA-Z0-9_-]{8,40}$/;
-  if (!SAFE_ID_RE.test(itemId)) {
-    res.status(400).json({ error: 'Invalid itemId format' });
-    return;
-  }
-
-  if (!ALL_ARCHIVE_KEYS.includes(archiveKey as typeof ALL_ARCHIVE_KEYS[number])) {
-    res.status(400).json({ error: 'Invalid archiveKey' });
-    return;
-  }
-
-  const db = getFirestore();
-  const userId = getDashboardUserId();
-  const userSnap = await db
-    .collection('users')
-    .doc(userId)
-    .collection('articles')
-    .doc(itemId)
-    .get();
-
-  if (!userSnap.exists) {
-    res.status(404).json({ error: 'Article not found' });
-    return;
-  }
-
-  const canonicalItemId = resolveCanonicalItemId(
-    itemId,
-    userSnap.data() as Record<string, unknown>
-  );
-  const docSnap = await db.collection('articles').doc(canonicalItemId).get();
-
-  if (!docSnap.exists) {
-    res.status(404).json({ error: 'Canonical article not found' });
-    return;
-  }
-
-  const doc = docSnap.data()!;
-  const archives = doc['archives'] as Record<string, ArchiveRecord> | undefined;
-  const resolved = resolveArchiveWithAlias(archives, archiveKey);
-  const archive = resolved?.archive;
-
-  if (!archive || archive.status !== 'success' || !archive.gcs_path) {
-    res.status(404).json({ error: `Archive '${archiveKey}' not available (status: ${archive?.status ?? 'absent'})` });
-    return;
-  }
-
-  // Strip gs://bucket-name/ prefix to get the object path
-  const gcsPath = archive.gcs_path;
-  let objectPath: string;
-  if (gcsPath.startsWith('gs://')) {
-    // Format: gs://bucket-name/path/to/object
-    const withoutScheme = gcsPath.slice(5);
-    const slashIdx = withoutScheme.indexOf('/');
-    objectPath = slashIdx >= 0 ? withoutScheme.slice(slashIdx + 1) : withoutScheme;
-  } else {
-    objectPath = gcsPath;
-  }
-
-  const storage = new Storage({ projectId: GCS_PROJECT_ID });
-  const bucket = storage.bucket(GCS_BUCKET);
-  const file = bucket.file(objectPath);
-
-  const expiresAt = new Date(Date.now() + SIGNED_URL_EXPIRY_MINUTES * 60 * 1000);
-
-  const [signedUrl] = await file.getSignedUrl({
-    version: 'v4',
-    action: 'read',
-    expires: expiresAt,
+  const result = await resolveAndSignArchive({
+    db: getFirestore(),
+    ownerUid: getDashboardUserId(),
+    itemId: query.itemId,
+    archiveKey: query.archiveKey,
   });
 
-  res.json({
-    url: signedUrl,
-    expires_at: expiresAt.toISOString(),
-    item_id: itemId,
-    canonical_item_id: canonicalItemId,
-    archive_key: archiveKey,
-    archive_source_key: resolved?.sourceKey ?? archiveKey,
-  });
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+
+  res.json(result.body);
 }

--- a/warg/cloud-functions/user-triggers/package.json
+++ b/warg/cloud-functions/user-triggers/package.json
@@ -13,7 +13,7 @@
     "node": "22"
   },
   "dependencies": {
-    "firebase-admin": "^13.0.2",
+    "firebase-admin": "^13.10.0",
     "firebase-functions": "^6.3.0"
   },
   "devDependencies": {

--- a/warg/docs/adr-do-cost.md
+++ b/warg/docs/adr-do-cost.md
@@ -40,11 +40,15 @@ Now, three layers guarantee containers do not outlive their job:
 1. **`stop()` per job** — `runMonolithInSandbox` keys the sandbox off the
    request id and stops it in a `finally` block, on success and on error. A
    failed `stop()` is logged and never masks the job's own outcome.
-2. **30s `sleepAfter` backstop** — the `Sandbox` subclass in
-   `workers/monolith/src/index.ts` sets `sleepAfter = '30s'` (wrangler's
+2. **5m `sleepAfter` backstop** — the `Sandbox` subclass in
+   `workers/monolith/src/index.ts` sets `sleepAfter = '5m'` (wrangler's
    `containers` config exposes no such key, so the class field is the
-   configuration surface). This reaps containers whose `stop()` was missed,
-   e.g. a worker crash mid-job.
+   configuration surface). The value must exceed the longest job (P99 ~180s)
+   because the inactivity alarm can fire during an in-flight exec
+   (cloudflare/containers#162) — `'5m'` clears that tail with margin.
+   Cost note: at a 1% `stop()` miss rate, orphaned containers idle up to 5
+   minutes before reaping, contributing ~21 GB-s/month — negligible versus
+   the 400k GB-s/month free tier.
 3. **Cron orphan sweep** — the gateway's existing 10-minute cron also calls
    the workflow worker for active sandbox quota leases and asks the monolith
    worker (`POST /container/stop`) to stop the container behind any lease
@@ -62,7 +66,8 @@ tracked separately).
 LoggerDO was keyed `idFromName(requestId)` — one DO instance per request,
 ~129k cold starts per 30 days. It is now keyed by UTC hour bucket
 (`bucket:YYYYMMDDHH`): roughly 24 warm instances per day replace ~4.3k
-per-request cold starts. Measured write rates (~0.4/s peak) are about 2,500×
+per-day cold starts (129k requests / 30 days). Measured write rates (~0.4/s
+peak) are about 2,500×
 below the per-instance throughput limit, so a single unsharded bucket per
 hour suffices.
 
@@ -92,10 +97,26 @@ re-key keeps SQLite-in-DO semantics, is reversible by redeploying the old
 keying (legacy data is untouched), and the container fix — not the logger —
 is the dominant lever.
 
+## Post-deploy observations to track
+
+(a) **SSE stream keep-alive** — each active SSE poll (`GET /request/:id/stream`)
+holds a LoggerDO awake for up to 2 minutes. When many dashboard tabs are open,
+the logger namespace wall-time will exceed the 24-instance baseline. Watch the
+logger DO wall-time metric when dashboards are in use.
+
+(b) **D1 routing read** — every post-init logger write does one D1 point-read
+(`SELECT created_at FROM requests_index`) to resolve the bucket. At ~129k
+requests/month that is ~129k reads/month, well under the 150M/month free tier.
+Revisit if request volume grows ~10×.
+
+(c) **Gateway cron sub-request** — the 10-minute orphan cron makes one
+sandbox-leases sub-request to the workflow worker per tick, regardless of load.
+The request count is negligible (~4,320/month).
+
 ## Rollback
 
 - **Container lifecycle:** revert the `finally`/`stop()` block, the
-  `sleepAfter` field, and re-add warm-pool slot passing. Redeploy.
+  `sleepAfter = '5m'` field, and re-add warm-pool slot passing. Redeploy.
 - **Logger keying:** point writes back at `idFromName(requestId)` and drop
   the dual-read. Redeploy. Bucket-era requests then need the same dual-read
   in reverse, so this is a fast-failure escape hatch, not a free undo.

--- a/warg/docs/adr-do-cost.md
+++ b/warg/docs/adr-do-cost.md
@@ -1,0 +1,112 @@
+# Decision record: cutting warg's Durable Objects duration cost
+
+Status: accepted (2026-06)
+Scope: monolith container lifecycle, LoggerDO keying scheme
+
+## Problem
+
+The Cloudflare bill spiked ~16× on the **Durable Objects duration** meter
+(GB-seconds active), from the ~$5 Workers Paid base to ~$18–22/month. The
+free allowance is 400k GB-s/month; GB-s ≈ invocations × wall-time × 0.128 GB
+(DOs bill at a fixed 128 MB regardless of real memory).
+
+The DO dashboard (30 days) settled which namespaces drive the meter:
+
+| DO namespace | Requests (30d) | Why it bills |
+|---|---|---|
+| monolith (Sandbox container DO) | 204k (59%) | longest wall times — the archive binary runs here |
+| logger (LoggerDO) | 129k (37%) | one cold-started instance per request |
+| workflow (BrowserQuotaDO) | 14k (4%) | hibernates between alarms; negligible |
+
+Two billing facts shaped the fix:
+
+1. **Cloudflare Workflows do not bill DO duration to the customer** — they
+   bill CPU-ms (30M/month free) plus storage. Tightening workflow retry loops
+   is a CPU/latency lever, not a GB-s lever.
+2. **Every container carries a backing DO billed at standard DO rates**, on
+   top of container compute (memory billed on *provisioned* size). A container
+   held alive is a DO accruing duration the whole time.
+
+## Decision 1: stop the monolith container per job (primary lever)
+
+The monolith worker previously pinned jobs to a warm pool of up to 5
+containers (`monolith-pool-<slot>`) with **no explicit stop and no
+`sleepAfter` configured** — the upstream Sandbox default keeps a container
+alive 10 minutes after its last activity, and pool reuse kept resetting that
+timer. Idle containers were the dominant GB-s driver.
+
+Now, three layers guarantee containers do not outlive their job:
+
+1. **`stop()` per job** — `runMonolithInSandbox` keys the sandbox off the
+   request id and stops it in a `finally` block, on success and on error. A
+   failed `stop()` is logged and never masks the job's own outcome.
+2. **30s `sleepAfter` backstop** — the `Sandbox` subclass in
+   `workers/monolith/src/index.ts` sets `sleepAfter = '30s'` (wrangler's
+   `containers` config exposes no such key, so the class field is the
+   configuration surface). This reaps containers whose `stop()` was missed,
+   e.g. a worker crash mid-job.
+3. **Cron orphan sweep** — the gateway's existing 10-minute cron also calls
+   the workflow worker for active sandbox quota leases and asks the monolith
+   worker (`POST /container/stop`) to stop the container behind any lease
+   older than the 5-minute lease TTL (a lease that old means its workflow
+   crashed before releasing).
+
+Trade-off accepted: every job cold-starts a container. Cost is prioritized
+over latency for this batch pipeline. The warm pool, its slot plumbing in the
+workflow worker, and the pool-id validation in the monolith worker were
+removed; `BrowserQuotaDO` still assigns slots internally (vestigial, cleanup
+tracked separately).
+
+## Decision 2: hour-bucketed LoggerDO (secondary lever)
+
+LoggerDO was keyed `idFromName(requestId)` — one DO instance per request,
+~129k cold starts per 30 days. It is now keyed by UTC hour bucket
+(`bucket:YYYYMMDDHH`): roughly 24 warm instances per day replace ~4.3k
+per-request cold starts. Measured write rates (~0.4/s peak) are about 2,500×
+below the per-instance throughput limit, so a single unsharded bucket per
+hour suffices.
+
+Consequences inside the DO:
+
+- `events` and `artifacts` gained a `request_id` column (plus indexes); every
+  method takes the request id and filters on it.
+- A request's bucket is the hour of its `created_at`. The init handler picks
+  the bucket and the stored `created_at` from the same timestamp; later
+  writes and reads derive the bucket from the D1 index (`requests_index
+  .created_at`) — request ids are UUIDs and encode no time, so this lookup is
+  what makes reads routable.
+- **Dual-read, no backfill:** pre-bucket requests still live in their legacy
+  per-request instances. Readers try the creation-hour bucket first and fall
+  back to the legacy instance when the bucket holds no row. On first access a
+  legacy instance migrates its own rows in place (adds `request_id`, adopts
+  rows under its single request). Legacy instances are never written by new
+  code, except `PATCH /request/:id` which follows the data for requests that
+  were mid-flight at cutover.
+
+### Why hour buckets over Workers Analytics Engine
+
+Moving the event store to WAE was rejected: it is operationally irreversible
+(append-only, external store), its billing is not yet active (pricing risk),
+and the SSE stream would need a write-through buffer anyway. The bucket
+re-key keeps SQLite-in-DO semantics, is reversible by redeploying the old
+keying (legacy data is untouched), and the container fix — not the logger —
+is the dominant lever.
+
+## Rollback
+
+- **Container lifecycle:** revert the `finally`/`stop()` block, the
+  `sleepAfter` field, and re-add warm-pool slot passing. Redeploy.
+- **Logger keying:** point writes back at `idFromName(requestId)` and drop
+  the dual-read. Redeploy. Bucket-era requests then need the same dual-read
+  in reverse, so this is a fast-failure escape hatch, not a free undo.
+
+## Verification
+
+- Unit/integration tests cover `stop()` on success/error/upload-failure
+  paths, the sweep logic, bucket multi-request isolation, legacy migration,
+  and dual-read fallbacks.
+- Post-deploy: the DO dashboard's `monolith` namespace wall-time should drop
+  to near zero between jobs, and `logger` invocations should fall from
+  thousands per day toward one warm instance per active hour.
+- The decisive check is the next invoice: DO duration back under
+  400k GB-s/month.

--- a/warg/eslint.config.js
+++ b/warg/eslint.config.js
@@ -1,18 +1,50 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import globals from 'globals';
 
 export default tseslint.config(
+  {
+    // Generated files and private tooling are not lint targets.
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/.wrangler/**',
+      '**/.ai/**',
+      '**/worker-configuration.d.ts'
+    ]
+  },
   eslint.configs.recommended,
   ...tseslint.configs.strict,
-  {
-    ignores: ['**/dist/**', '**/node_modules/**', '**/.wrangler/**']
-  },
   {
     rules: {
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
-      ]
+      ],
+      // The codebase deliberately uses non-null assertions for lazy-init
+      // state (Durable Object loadState/ensureSchema patterns and length
+      // checks immediately above the access). strict's blanket ban is a
+      // style decision this repo has not adopted.
+      '@typescript-eslint/no-non-null-assertion': 'off'
+    }
+  },
+  {
+    // Browser dashboard: plain JS modules served as-is.
+    files: ['pages/dashboard/**/*.js'],
+    languageOptions: { globals: globals.browser }
+  },
+  {
+    // Node maintenance scripts.
+    files: ['scripts/**/*.js', 'scripts/**/*.mjs'],
+    languageOptions: { globals: globals.node }
+  },
+  {
+    // Tests stub external surfaces aggressively; `any` and empty mock
+    // classes are acceptable there.
+    files: ['**/*.test.ts', '**/__tests__/**'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-extraneous-class': 'off'
     }
   }
 );

--- a/warg/package.json
+++ b/warg/package.json
@@ -18,15 +18,30 @@
   },
   "devDependencies": {
     "@cloudflare/puppeteer": "^1.0.5",
-    "@typescript-eslint/eslint-plugin": "^8.21.0",
-    "@typescript-eslint/parser": "^8.21.0",
+    "@typescript-eslint/eslint-plugin": "^8.61.0",
+    "@typescript-eslint/parser": "^8.61.0",
     "concurrently": "^9.1.2",
-    "eslint": "^9.18.0",
+    "eslint": "^9.39.4",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3",
-    "wrangler": "^4.65.0"
+    "wrangler": "^4.99.0"
   },
   "dependencies": {
     "@cloudflare/workerd-windows-64": "^1.20260131.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "rollup": ">=4.59.0",
+      "undici": ">=7.24.0",
+      "defu": ">=6.1.5",
+      "protobufjs": ">=7.5.6 <8",
+      "path-to-regexp": ">=0.1.13",
+      "fast-xml-parser": ">=5.5.6",
+      "basic-ftp": ">=5.3.1",
+      "minimatch": ">=9.0.7",
+      "flatted": ">=3.4.2",
+      "picomatch": ">=4.0.4",
+      "shell-quote": ">=1.8.4"
+    }
   }
 }

--- a/warg/package.json
+++ b/warg/package.json
@@ -18,12 +18,12 @@
   },
   "devDependencies": {
     "@cloudflare/puppeteer": "^1.0.5",
-    "@typescript-eslint/eslint-plugin": "^8.61.0",
-    "@typescript-eslint/parser": "^8.61.0",
     "concurrently": "^9.1.2",
     "eslint": "^9.39.4",
+    "globals": "^17.6.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3",
+    "typescript-eslint": "^8.61.0",
     "wrangler": "^4.99.0"
   },
   "dependencies": {

--- a/warg/package.json
+++ b/warg/package.json
@@ -14,7 +14,8 @@
     "deploy": "bash scripts/deploy.sh",
     "deploy:pages": "bash scripts/deploy.sh --with-pages",
     "deploy:all": "bash scripts/deploy.sh --all",
-    "deploy:quick": "bash scripts/deploy.sh --skip-checks"
+    "deploy:quick": "bash scripts/deploy.sh --skip-checks",
+    "deploy:workers": "pnpm --filter @warg/logger deploy && pnpm --filter @warg/monolith deploy && pnpm --filter @warg/workflow deploy && pnpm --filter @warg/gateway deploy"
   },
   "devDependencies": {
     "@cloudflare/puppeteer": "^1.0.5",

--- a/warg/packages/shared/package.json
+++ b/warg/packages/shared/package.json
@@ -16,6 +16,6 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/packages/shared/src/crypto.ts
+++ b/warg/packages/shared/src/crypto.ts
@@ -2,7 +2,7 @@
  * Computes SHA-256 hash of data using WebCrypto API.
  * Works in both Node.js and Cloudflare Workers.
  */
-export async function sha256(data: ArrayBuffer | Uint8Array): Promise<string> {
+export async function sha256(data: BufferSource): Promise<string> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = new Uint8Array(hashBuffer);
   return Array.from(hashArray)

--- a/warg/packages/shared/tsconfig.json
+++ b/warg/packages/shared/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
+    "lib": ["ES2022", "DOM"],
     "types": []
   },
   "include": ["src/**/*.ts"]

--- a/warg/pages/dashboard-v2/package.json
+++ b/warg/pages/dashboard-v2/package.json
@@ -21,6 +21,6 @@
     "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^7.3.5"
   }
 }

--- a/warg/pages/dashboard-v2/src/features/dashboard/ErrorsView.tsx
+++ b/warg/pages/dashboard-v2/src/features/dashboard/ErrorsView.tsx
@@ -1,4 +1,3 @@
-import { useApi } from '@/hooks/useApi';
 import { useInterval } from '@/hooks/useInterval';
 import { useSettings } from '@/hooks/useSettings';
 import { fetchStats, fetchRequests, fetchRequestDetail } from '@/api/endpoints';

--- a/warg/pages/dashboard-v2/src/hooks/useApi.ts
+++ b/warg/pages/dashboard-v2/src/hooks/useApi.ts
@@ -34,7 +34,6 @@ export function useApi<T>(
 
   useEffect(() => {
     refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
   return { data, loading, error, refetch };

--- a/warg/pages/dashboard/functions/api/__tests__/pipeline-state.test.ts
+++ b/warg/pages/dashboard/functions/api/__tests__/pipeline-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-// @ts-ignore - dashboard runtime modules are plain JS and intentionally imported in tests.
+// @ts-expect-error - dashboard runtime modules are plain JS and intentionally imported in tests.
 import { derivePipelineState } from '../../../modules/components.js';
 
 type TestEvent = {

--- a/warg/pages/dashboard/functions/api/__tests__/proxy-functions.test.ts
+++ b/warg/pages/dashboard/functions/api/__tests__/proxy-functions.test.ts
@@ -187,7 +187,7 @@ describe('begin proxy', () => {
       PUBLIC_API_KEY: 'pub-key',
     } as any;
 
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: any, init?: any) => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: any, _init?: any) => {
       const url = String(input);
       if (url === 'https://dashboard-api.example.com/articles/abc12345/bootstrap') {
         return jsonResponse({

--- a/warg/pages/dashboard/functions/api/__tests__/route-state.test.ts
+++ b/warg/pages/dashboard/functions/api/__tests__/route-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-// @ts-ignore - dashboard runtime modules are plain JS and intentionally imported in tests.
+// @ts-expect-error - dashboard runtime modules are plain JS and intentionally imported in tests.
 import { parseLocation, buildUrl, normalizeRouteState } from '../../../modules/route-state.js';
 
 describe('route-state codec', () => {

--- a/warg/pages/dashboard/modules/components.js
+++ b/warg/pages/dashboard/modules/components.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { PIPELINE_STEPS, STAGE_COLORS } from './state.js';
+import { PIPELINE_STEPS } from './state.js';
 import { escapeHtml, formatDuration, formatTime } from './utils.js';
 
 export function statusBadgeHtml(stage) {

--- a/warg/pnpm-lock.yaml
+++ b/warg/pnpm-lock.yaml
@@ -4,6 +4,19 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  rollup: '>=4.59.0'
+  undici: '>=7.24.0'
+  defu: '>=6.1.5'
+  protobufjs: '>=7.5.6 <8'
+  path-to-regexp: '>=0.1.13'
+  fast-xml-parser: '>=5.5.6'
+  basic-ftp: '>=5.3.1'
+  minimatch: '>=9.0.7'
+  flatted: '>=3.4.2'
+  picomatch: '>=4.0.4'
+  shell-quote: '>=1.8.4'
+
 importers:
 
   .:
@@ -16,17 +29,17 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@typescript-eslint/eslint-plugin':
-        specifier: ^8.21.0
-        version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        specifier: ^8.61.0
+        version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
-        specifier: ^8.21.0
-        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        specifier: ^8.61.0
+        version: 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
       eslint:
-        specifier: ^9.18.0
-        version: 9.39.2(jiti@2.6.1)
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -34,8 +47,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
       wrangler:
-        specifier: ^4.65.0
-        version: 4.65.0
+        specifier: ^4.99.0
+        version: 4.99.0(@cloudflare/workers-types@4.20260609.1)
 
   cloud-functions/archive-gateway:
     dependencies:
@@ -43,11 +56,11 @@ importers:
         specifier: ^7.15.0
         version: 7.19.0
       firebase-admin:
-        specifier: ^13.0.2
-        version: 13.6.1
+        specifier: ^13.10.0
+        version: 13.10.0
       firebase-functions:
         specifier: ^6.3.0
-        version: 6.6.0(firebase-admin@13.6.1)
+        version: 6.6.0(firebase-admin@13.10.0)
     devDependencies:
       '@types/node':
         specifier: ^22.10.7
@@ -59,11 +72,11 @@ importers:
   cloud-functions/backfill-archiver:
     dependencies:
       firebase-admin:
-        specifier: ^13.0.2
-        version: 13.6.1
+        specifier: ^13.10.0
+        version: 13.10.0
       firebase-functions:
         specifier: ^6.3.0
-        version: 6.6.0(firebase-admin@13.6.1)
+        version: 6.6.0(firebase-admin@13.10.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -75,8 +88,8 @@ importers:
   cloud-functions/backfill-scripts:
     dependencies:
       firebase-admin:
-        specifier: ^13.0.2
-        version: 13.6.1
+        specifier: ^13.10.0
+        version: 13.10.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -85,8 +98,8 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   cloud-functions/dashboard-api:
     dependencies:
@@ -94,11 +107,11 @@ importers:
         specifier: ^7.15.0
         version: 7.19.0
       firebase-admin:
-        specifier: ^13.0.2
-        version: 13.6.1
+        specifier: ^13.10.0
+        version: 13.10.0
       firebase-functions:
         specifier: ^6.3.0
-        version: 6.6.0(firebase-admin@13.6.1)
+        version: 6.6.0(firebase-admin@13.10.0)
     devDependencies:
       '@types/node':
         specifier: ^22.10.7
@@ -110,11 +123,11 @@ importers:
   cloud-functions/user-triggers:
     dependencies:
       firebase-admin:
-        specifier: ^13.0.2
-        version: 13.6.1
+        specifier: ^13.10.0
+        version: 13.10.0
       firebase-functions:
         specifier: ^6.3.0
-        version: 6.6.0(firebase-admin@13.6.1)
+        version: 6.6.0(firebase-admin@13.10.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -126,8 +139,8 @@ importers:
   packages/shared:
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   pages/dashboard: {}
 
@@ -145,7 +158,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.3.0(vite@6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.3.0(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -154,7 +167,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.7.0(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.0
@@ -162,8 +175,8 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
-        specifier: ^6.0.0
-        version: 6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
 
   workers/gateway:
     dependencies:
@@ -172,8 +185,8 @@ importers:
         version: link:../../packages/shared
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/gcs:
     dependencies:
@@ -182,8 +195,8 @@ importers:
         version: link:../../packages/shared
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/hyperrenderer:
     dependencies:
@@ -192,8 +205,8 @@ importers:
         version: link:../../packages/shared
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/logger:
     dependencies:
@@ -202,14 +215,14 @@ importers:
         version: link:../../packages/shared
     devDependencies:
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.8.1
-        version: 0.8.71(@cloudflare/workers-types@4.20260130.0)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@22.19.7)(lightningcss@1.32.0))
+        specifier: ^0.16.14
+        version: 0.16.14(@cloudflare/workers-types@4.20260609.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)))
       '@cloudflare/workers-types':
-        specifier: ^4.20250123.0
-        version: 4.20260130.0
+        specifier: ^4.20260609.1
+        version: 4.20260609.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/monolith:
     dependencies:
@@ -224,8 +237,8 @@ importers:
         version: 1.0.20
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/readability:
     dependencies:
@@ -240,8 +253,8 @@ importers:
         version: 0.18.12
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
   workers/renderer:
     dependencies:
@@ -265,8 +278,8 @@ importers:
         version: link:../../packages/shared
     devDependencies:
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -356,13 +369,9 @@ packages:
   '@cloudflare/containers@0.0.30':
     resolution: {integrity: sha512-i148xBgmyn/pje82ZIyuTr/Ae0BT/YWwa1/GTJcw6DxEjUHAzZLaBCiX446U9OeuJ2rBh/L/9FIzxX5iYNt1AQ==}
 
-  '@cloudflare/kv-asset-handler@0.4.0':
-    resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
-    engines: {node: '>=18.0.0'}
-
-  '@cloudflare/kv-asset-handler@0.4.2':
-    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
-    engines: {node: '>=18.0.0'}
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
 
   '@cloudflare/puppeteer@1.0.5':
     resolution: {integrity: sha512-sKVtc9eTe+ulDqFGk1AcU1cgw3fuLvT75eqHDApvE1d/ZTesBD/r2Iey6elQ9uq/jBj0SjEOM1GVYi0Rojzeaw==}
@@ -379,84 +388,45 @@ packages:
       '@opencode-ai/sdk':
         optional: true
 
-  '@cloudflare/unenv-preset@2.12.1':
-    resolution: {integrity: sha512-tP/Wi+40aBJovonSNJSsS7aFJY0xjuckKplmzDs2Xat06BJ68B6iG7YDUWXJL8gNn0gqW7YC5WhlYhO3QbugQA==}
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
-      workerd: ^1.20260115.0
+      workerd: '>1.20260305.0 <2.0.0-0'
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  '@cloudflare/unenv-preset@2.7.3':
-    resolution: {integrity: sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw==}
+  '@cloudflare/vitest-pool-workers@0.16.14':
+    resolution: {integrity: sha512-QEoC+S0qhT/60Yy/9H96hmVDOSEc0lEV2HiBTCVB0xepXc96ig6bWxPyeDXmafOYv/cNiyarS8eP+CK8WjT46A==}
     peerDependencies:
-      unenv: 2.0.0-rc.21
-      workerd: ^1.20250828.1
-    peerDependenciesMeta:
-      workerd:
-        optional: true
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
 
-  '@cloudflare/vitest-pool-workers@0.8.71':
-    resolution: {integrity: sha512-keu2HCLQfRNwbmLBCDXJgCFpANTaYnQpE01fBOo4CNwiWHUT7SZGN7w64RKiSWRHyYppStXBuE5Ng7F42+flpg==}
-    peerDependencies:
-      '@vitest/runner': 2.0.x - 3.2.x
-      '@vitest/snapshot': 2.0.x - 3.2.x
-      vitest: 2.0.x - 3.2.x
-
-  '@cloudflare/workerd-darwin-64@1.20250906.0':
-    resolution: {integrity: sha512-E+X/YYH9BmX0ew2j/mAWFif2z05NMNuhCTlNYEGLkqMe99K15UewBqajL9pMcMUKxylnlrEoK3VNxl33DkbnPA==}
+  '@cloudflare/workerd-darwin-64@1.20260609.1':
+    resolution: {integrity: sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260212.0':
-    resolution: {integrity: sha512-kLxuYutk88Wlo7edp8mlkN68TgZZ9237SUnuX9kNaD5jcOdblUqiBctMRZeRcPsuoX/3g2t0vS4ga02NBEVRNg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20250906.0':
-    resolution: {integrity: sha512-X5apsZ1SFW4FYTM19ISHf8005FJMPfrcf4U5rO0tdj+TeJgQgXuZ57IG0WeW7SpLVeBo8hM6WC8CovZh41AfnA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
+    resolution: {integrity: sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260212.0':
-    resolution: {integrity: sha512-fqoqQWMA1D0ZzDOD8sp0allREM2M8GHdpxMXQ8EdZpZ70z5bJbJ9Vr4qe35++FNIZJspsDHfTw3Xm/M4ELm/dQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-linux-64@1.20250906.0':
-    resolution: {integrity: sha512-rlKzWgsLnlQ5Nt9W69YBJKcmTmZbOGu0edUsenXPmc6wzULUxoQpi7ZE9k3TfTonJx4WoQsQlzCUamRYFsX+0Q==}
+  '@cloudflare/workerd-linux-64@1.20260609.1':
+    resolution: {integrity: sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260212.0':
-    resolution: {integrity: sha512-bCSQoZzDzV5MSh4ueWo1DgmOn4Hf3QBu4Yo3eQFXA2llYFIu/sZgRtkEehw1X2/SY5Sn6O0EMCqxJYRf82Wdeg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20250906.0':
-    resolution: {integrity: sha512-DdedhiQ+SeLzpg7BpcLrIPEZ33QKioJQ1wvL4X7nuLzEB9rWzS37NNNahQzc1+44rhG4fyiHbXBPOeox4B9XVA==}
+  '@cloudflare/workerd-linux-arm64@1.20260609.1':
+    resolution: {integrity: sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20260212.0':
-    resolution: {integrity: sha512-GPvp1iiKQodtbUDi6OmR5I0vD75lawB54tdYGtmypuHC7ZOI2WhBmhb3wCxgnQNOG1z7mhCQrzRCoqrKwYbVWQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cloudflare/workerd-windows-64@1.20250906.0':
-    resolution: {integrity: sha512-Q8Qjfs8jGVILnZL6vUpQ90q/8MTCYaGR3d1LGxZMBqte8Vr7xF3KFHPEy7tFs0j0mMjnqCYzlofmPNY+9ZaDRg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20260205.0':
     resolution: {integrity: sha512-SMPW5jCZYOG7XFIglSlsgN8ivcl0pCrSAYxCwxtWvZ88whhcDB/aISNtiQiDZujPH8tIo2hE5dEkxW7tGEwc3A==}
@@ -464,14 +434,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260212.0':
-    resolution: {integrity: sha512-wHRI218Xn4ndgWJCUHH4Zx0YlU5q/o6OmcxXkcw95tJOsQn4lDrhppioPh4eScxJZALf2X+ODeZcyQTCq5exGw==}
+  '@cloudflare/workerd-windows-64@1.20260609.1':
+    resolution: {integrity: sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260130.0':
-    resolution: {integrity: sha512-eVJZjA4o0ANE/RX5g6mBs5MKRQxcSJYDPsFj8SPul7FDSFv682UzwXK3i0CSdIy/rtDNrMRmwJZ8KxANg2bY8A==}
+  '@cloudflare/workers-types@4.20260609.1':
+    resolution: {integrity: sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -480,52 +450,16 @@ packages:
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.25.4':
-    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.25.4':
-    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.4':
-    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -534,52 +468,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.4':
-    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.4':
-    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -588,34 +486,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.25.4':
-    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.4':
-    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -624,34 +498,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.25.4':
-    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.4':
-    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -660,34 +510,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.4':
-    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.4':
-    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -696,34 +522,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.4':
-    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.4':
-    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -732,34 +534,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.4':
-    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.4':
-    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -768,46 +546,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.4':
-    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.4':
-    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -816,28 +564,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.4':
-    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -852,35 +582,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.25.4':
-    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.25.4':
-    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
@@ -888,34 +594,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.4':
-    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.4':
-    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -934,8 +616,8 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/config-helpers@0.4.2':
@@ -946,12 +628,12 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.7':
@@ -1051,22 +733,10 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -1075,19 +745,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -1095,19 +755,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -1125,19 +775,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
@@ -1145,19 +785,9 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
@@ -1165,22 +795,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.5':
@@ -1201,22 +819,10 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.5':
@@ -1225,22 +831,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
@@ -1248,11 +842,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1265,22 +854,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -1315,6 +892,9 @@ packages:
     resolution: {integrity: sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==}
     engines: {node: '>=14.0.0'}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -1334,20 +914,20 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -1355,8 +935,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@puppeteer/browsers@2.2.4':
     resolution: {integrity: sha512-BdG2qiI1dn89OTUUsx2GZSpUzW+DRffR1wlMJyKxVHYrhnKoELSDxDd+2XImUkuWPEKk76H5FcM/gPFrEK1Tfw==}
@@ -1366,128 +946,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.57.1':
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.57.1':
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
 
@@ -1497,6 +1077,9 @@ packages:
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -1613,14 +1196,23 @@ packages:
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/express-serve-static-core@4.19.8':
     resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
@@ -1681,63 +1273,63 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.54.0':
-    resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.54.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.54.0':
-    resolution: {integrity: sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==}
+  '@typescript-eslint/parser@8.61.0':
+    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.54.0':
-    resolution: {integrity: sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==}
+  '@typescript-eslint/project-service@8.61.0':
+    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.54.0':
-    resolution: {integrity: sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==}
+  '@typescript-eslint/scope-manager@8.61.0':
+    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.54.0':
-    resolution: {integrity: sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.54.0':
-    resolution: {integrity: sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==}
+  '@typescript-eslint/tsconfig-utils@8.61.0':
+    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.54.0':
-    resolution: {integrity: sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.54.0':
-    resolution: {integrity: sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==}
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.54.0':
-    resolution: {integrity: sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==}
+  '@typescript-eslint/types@8.61.0':
+    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.0':
+    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.54.0':
-    resolution: {integrity: sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==}
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
@@ -1746,34 +1338,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1788,15 +1380,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
-
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -1810,8 +1393,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1820,6 +1403,9 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1856,8 +1442,9 @@ packages:
       react-native-b4a:
         optional: true
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -1905,15 +1492,12 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.1.0:
-    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
+  basic-ftp@6.0.1:
+    resolution: {integrity: sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==}
     engines: {node: '>=10.0.0'}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  birpc@0.2.14:
-    resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -1925,11 +1509,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1949,10 +1531,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1968,20 +1546,16 @@ packages:
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
-
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1994,19 +1568,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.2.1:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
@@ -2056,6 +1620,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -2077,15 +1645,8 @@ packages:
       supports-color:
         optional: true
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -2106,9 +1667,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  devalue@5.6.2:
-    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
 
   devtools-protocol@0.0.1299070:
     resolution: {integrity: sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg==}
@@ -2175,8 +1733,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2185,16 +1743,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.25.4:
-    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -2229,8 +1777,12 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -2278,10 +1830,6 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
-  exit-hook@2.2.1:
-    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2289,9 +1837,6 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
-
-  exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2317,8 +1862,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@5.3.4:
-    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
 
   faye-websocket@0.11.4:
@@ -2332,10 +1880,14 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2349,8 +1901,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  firebase-admin@13.6.1:
-    resolution: {integrity: sha512-Zgc6yPtmPxAZo+FoK6LMG6zpSEsoSK8ifIR+IqF4oWuC3uWZU40OjxgfLTSFcsRlj/k/wD66zNv2UiTRreCNSw==}
+  firebase-admin@13.10.0:
+    resolution: {integrity: sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==}
     engines: {node: '>=18'}
 
   firebase-functions@6.6.0:
@@ -2364,12 +1916,16 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   form-data@2.5.5:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2394,9 +1950,17 @@ packages:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
 
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2426,11 +1990,12 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
     engines: {node: '>=18'}
 
   google-auth-library@9.15.1:
@@ -2443,6 +2008,10 @@ packages:
 
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
   gopd@1.2.0:
@@ -2537,9 +2106,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2740,9 +2306,6 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2793,22 +2356,14 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  miniflare@4.20250906.0:
-    resolution: {integrity: sha512-T/RWn1sa0ien80s6NjU+Un/tj12gR6wqScZoiLeMJDD4/fK0UXfnbWXJDubnUED8Xjm7RPQ5ESYdE+mhPmMtuQ==}
-    engines: {node: '>=18.0.0'}
+  miniflare@4.20260609.0:
+    resolution: {integrity: sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@4.20260212.0:
-    resolution: {integrity: sha512-Lgxq83EuR2q/0/DAVOSGXhXS1V7GDB04HVggoPsenQng8sqEDR3hO4FigIw5ZI2Sv2X7kIc30NCzGHJlCFIYWg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -2832,6 +2387,11 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -2841,9 +2401,9 @@ packages:
       encoding:
         optional: true
 
-  node-forge@1.3.3:
-    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
-    engines: {node: '>= 6.13.0'}
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
@@ -2863,8 +2423,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2905,25 +2466,19 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -2931,8 +2486,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.6:
@@ -2956,8 +2511,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -3033,8 +2588,8 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  rollup@4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3073,10 +2628,6 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3089,8 +2640,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -3111,9 +2662,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -3142,12 +2690,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  stoppable@1.1.0:
-    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
-    engines: {node: '>=4', npm: '>=6'}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
@@ -3173,8 +2717,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
@@ -3217,23 +2761,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
@@ -3247,8 +2784,8 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -3269,9 +2806,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
-
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
@@ -3281,12 +2815,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
-  unenv@2.0.0-rc.21:
-    resolution: {integrity: sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==}
+  undici@8.4.1:
+    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -3311,10 +2842,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -3327,55 +2854,19 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
-      less: '*'
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -3403,23 +2894,39 @@ packages:
       yaml:
         optional: true
 
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
+      '@opentelemetry/api':
+        optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3427,6 +2934,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3456,32 +2967,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20250906.0:
-    resolution: {integrity: sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw==}
+  workerd@1.20260609.1:
+    resolution: {integrity: sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260212.0:
-    resolution: {integrity: sha512-4B9BoZUzKSRv3pVZGEPh7OX+Q817hpUqAUtz5O0TxJVqo4OsYJAUA/sY177Q5ha/twjT9KaJt2DtQzE+oyCOzw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  wrangler@4.35.0:
-    resolution: {integrity: sha512-HbyXtbrh4Fi3mU8ussY85tVdQ74qpVS1vctUgaPc+bPrXBTqfDLkZ6VRtHAVF/eBhz4SFmhJtCQpN1caY2Ak8A==}
-    engines: {node: '>=18.0.0'}
+  wrangler@4.99.0:
+    resolution: {integrity: sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250906.0
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
-  wrangler@4.65.0:
-    resolution: {integrity: sha512-R+n3o3tlGzLK9I4fGocPReOuvcnjhtOL2aCVKkHMeuEwt9pPbOO4FxJtx/ec5cIUG/otRyJnfQGCAr9DplBVng==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.20260212.0
+      '@cloudflare/workers-types': ^4.20260609.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3504,6 +3000,22 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3536,8 +3048,8 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -3655,11 +3167,7 @@ snapshots:
 
   '@cloudflare/containers@0.0.30': {}
 
-  '@cloudflare/kv-asset-handler@0.4.0':
-    dependencies:
-      mime: 3.0.0
-
-  '@cloudflare/kv-asset-handler@0.4.2': {}
+  '@cloudflare/kv-asset-handler@0.5.0': {}
 
   '@cloudflare/puppeteer@1.0.5':
     dependencies:
@@ -3679,68 +3187,45 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.0.30
 
-  '@cloudflare/unenv-preset@2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260212.0
+      workerd: 1.20260609.1
 
-  '@cloudflare/unenv-preset@2.7.3(unenv@2.0.0-rc.21)(workerd@1.20250906.0)':
+  '@cloudflare/vitest-pool-workers@0.16.14(@cloudflare/workers-types@4.20260609.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
-      unenv: 2.0.0-rc.21
-    optionalDependencies:
-      workerd: 1.20250906.0
-
-  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20260130.0)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@22.19.7)(lightningcss@1.32.0))':
-    dependencies:
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      birpc: 0.2.14
-      cjs-module-lexer: 1.4.3
-      devalue: 5.6.2
-      miniflare: 4.20250906.0
-      semver: 7.7.3
-      vitest: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
-      wrangler: 4.35.0(@cloudflare/workers-types@4.20260130.0)
-      zod: 3.22.3
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.27.3
+      miniflare: 4.20260609.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
+      wrangler: 4.99.0(@cloudflare/workers-types@4.20260609.1)
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/workerd-darwin-64@1.20250906.0':
+  '@cloudflare/workerd-darwin-64@1.20260609.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260212.0':
+  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250906.0':
+  '@cloudflare/workerd-linux-64@1.20260609.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260212.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20250906.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20260212.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20250906.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20260212.0':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20250906.0':
+  '@cloudflare/workerd-linux-arm64@1.20260609.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260205.0': {}
 
-  '@cloudflare/workerd-windows-64@1.20260212.0':
+  '@cloudflare/workerd-windows-64@1.20260609.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260130.0': {}
+  '@cloudflare/workers-types@4.20260609.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3751,184 +3236,64 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/aix-ppc64@0.25.4':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.3':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
-  '@esbuild/android-arm@0.25.4':
-    optional: true
-
   '@esbuild/android-arm@0.27.3':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
-    optional: true
-
-  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.4':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.4':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.4':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.4':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.3':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.4':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.3':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.4':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.4':
-    optional: true
-
   '@esbuild/linux-x64@0.27.3':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.4':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -3937,54 +3302,30 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.4':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.4':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3996,21 +3337,21 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.39.2': {}
+  '@eslint/js@9.39.4': {}
 
   '@eslint/object-schema@2.1.7': {}
 
@@ -4070,7 +3411,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 4.6.1
-      protobufjs: 7.5.4
+      protobufjs: 7.6.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4093,7 +3434,7 @@ snapshots:
       abort-controller: 3.0.0
       async-retry: 1.3.3
       duplexify: 4.1.3
-      fast-xml-parser: 5.3.4
+      fast-xml-parser: 5.8.0
       gaxios: 6.7.1
       google-auth-library: 9.15.1
       html-entities: 2.6.0
@@ -4116,7 +3457,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.2
       yargs: 17.7.2
     optional: true
 
@@ -4124,7 +3465,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.2
       yargs: 17.7.2
     optional: true
 
@@ -4141,19 +3482,9 @@ snapshots:
 
   '@img/colour@1.0.0': {}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -4161,25 +3492,13 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -4191,43 +3510,21 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -4245,19 +3542,9 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-    optional: true
-
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -4265,29 +3552,14 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.33.5':
-    dependencies:
-      '@emnapi/runtime': 1.8.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -4298,13 +3570,7 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
-    optional: true
-
   '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -4339,6 +3605,8 @@ snapshots:
 
   '@mozilla/readability@0.5.0': {}
 
+  '@nodable/entities@2.1.1': {}
+
   '@opentelemetry/api@1.9.0':
     optional: true
 
@@ -4358,24 +3626,23 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@puppeteer/browsers@2.2.4':
     dependencies:
@@ -4395,84 +3662,86 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
+  '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.57.1':
+  '@rollup/rollup-android-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
+  '@rollup/rollup-darwin-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.57.1':
+  '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
+  '@rollup/rollup-freebsd-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
+  '@rollup/rollup-freebsd-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
+  '@rollup/rollup-linux-x64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
+  '@rollup/rollup-openbsd-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
+  '@rollup/rollup-openharmony-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.14': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -4535,12 +3804,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -4574,6 +3843,11 @@ snapshots:
 
   '@types/caseless@0.12.5': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.7
@@ -4582,7 +3856,11 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
@@ -4659,98 +3937,98 @@ snapshots:
       '@types/node': 22.19.7
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.54.0
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.54.0
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.54.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.54.0':
+  '@typescript-eslint/scope-manager@8.61.0':
     dependencies:
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/visitor-keys': 8.54.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
 
-  '@typescript-eslint/tsconfig-utils@8.54.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.54.0': {}
+  '@typescript-eslint/types@8.61.0': {}
 
-  '@typescript-eslint/typescript-estree@8.54.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/visitor-keys': 8.54.0
+      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.54.0':
+  '@typescript-eslint/visitor-keys@8.61.0':
     dependencies:
-      '@typescript-eslint/types': 8.54.0
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4758,49 +4036,50 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
+  '@vitest/expect@4.1.8':
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      tinyrainbow: 1.2.0
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.7)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@vitest/spy': 2.1.9
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.7)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
 
-  '@vitest/pretty-format@2.1.9':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@2.1.9':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
 
-  '@vitest/snapshot@2.1.9':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
-      pathe: 1.1.2
+      pathe: 2.0.3
 
-  '@vitest/spy@2.1.9':
-    dependencies:
-      tinyspy: 3.0.2
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@2.1.9':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
-      loupe: 3.2.1
-      tinyrainbow: 1.2.0
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   abort-controller@3.0.0:
     dependencies:
@@ -4815,10 +4094,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.2: {}
-
-  acorn@8.14.0: {}
-
   acorn@8.15.0: {}
 
   agent-base@6.0.2:
@@ -4829,7 +4104,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -4841,6 +4116,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  anynum@1.0.0: {}
 
   argparse@2.0.1: {}
 
@@ -4864,7 +4141,7 @@ snapshots:
 
   b4a@1.7.3: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
 
@@ -4907,11 +4184,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
-  basic-ftp@5.1.0: {}
+  basic-ftp@6.0.1: {}
 
   bignumber.js@9.3.1: {}
-
-  birpc@0.2.14: {}
 
   blake3-wasm@2.1.5: {}
 
@@ -4934,14 +4209,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@5.0.6:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -4962,8 +4232,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cac@6.7.14: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4978,22 +4246,14 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  check-error@2.1.3: {}
-
-  cjs-module-lexer@1.4.3: {}
+  cjs-module-lexer@1.2.3: {}
 
   cliui@8.0.1:
     dependencies:
@@ -5007,27 +4267,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  concat-map@0.0.1: {}
 
   concurrently@9.2.1:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -5071,6 +4319,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-uri-to-buffer@6.0.2: {}
 
   debug@2.6.9:
@@ -5081,11 +4331,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  deep-eql@5.0.2: {}
-
   deep-is@0.1.4: {}
-
-  defu@6.1.4: {}
 
   degenerator@5.0.1:
     dependencies:
@@ -5100,8 +4346,6 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
-
-  devalue@5.6.2: {}
 
   devtools-protocol@0.0.1299070: {}
 
@@ -5167,7 +4411,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5179,60 +4423,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
-
-  esbuild@0.25.4:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.4
-      '@esbuild/android-arm': 0.25.4
-      '@esbuild/android-arm64': 0.25.4
-      '@esbuild/android-x64': 0.25.4
-      '@esbuild/darwin-arm64': 0.25.4
-      '@esbuild/darwin-x64': 0.25.4
-      '@esbuild/freebsd-arm64': 0.25.4
-      '@esbuild/freebsd-x64': 0.25.4
-      '@esbuild/linux-arm': 0.25.4
-      '@esbuild/linux-arm64': 0.25.4
-      '@esbuild/linux-ia32': 0.25.4
-      '@esbuild/linux-loong64': 0.25.4
-      '@esbuild/linux-mips64el': 0.25.4
-      '@esbuild/linux-ppc64': 0.25.4
-      '@esbuild/linux-riscv64': 0.25.4
-      '@esbuild/linux-s390x': 0.25.4
-      '@esbuild/linux-x64': 0.25.4
-      '@esbuild/netbsd-arm64': 0.25.4
-      '@esbuild/netbsd-x64': 0.25.4
-      '@esbuild/openbsd-arm64': 0.25.4
-      '@esbuild/openbsd-x64': 0.25.4
-      '@esbuild/sunos-x64': 0.25.4
-      '@esbuild/win32-arm64': 0.25.4
-      '@esbuild/win32-ia32': 0.25.4
-      '@esbuild/win32-x64': 0.25.4
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -5286,21 +4476,23 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -5319,7 +4511,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5361,8 +4553,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
-  exit-hook@2.2.1: {}
-
   expect-type@1.3.0: {}
 
   express@4.22.1:
@@ -5386,7 +4576,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 6.3.0
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
@@ -5400,8 +4590,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  exsolve@1.0.8: {}
 
   extend@3.0.2: {}
 
@@ -5425,9 +4613,18 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@5.3.4:
+  fast-xml-builder@1.2.0:
     dependencies:
-      strnum: 2.1.2
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
+      xml-naming: 0.1.0
 
   faye-websocket@0.11.4:
     dependencies:
@@ -5437,9 +4634,14 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5462,19 +4664,16 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  firebase-admin@13.6.1:
+  firebase-admin@13.10.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
       '@firebase/database-types': 1.0.16
-      '@types/node': 22.19.7
       farmhash-modern: 1.1.0
       fast-deep-equal: 3.1.3
-      google-auth-library: 9.15.1
+      google-auth-library: 10.7.0
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
-      node-forge: 1.3.3
-      uuid: 11.1.0
     optionalDependencies:
       '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0
@@ -5482,23 +4681,23 @@ snapshots:
       - encoding
       - supports-color
 
-  firebase-functions@6.6.0(firebase-admin@13.6.1):
+  firebase-functions@6.6.0(firebase-admin@13.10.0):
     dependencies:
       '@types/cors': 2.8.19
       '@types/express': 4.17.25
       cors: 2.8.6
       express: 4.22.1
-      firebase-admin: 13.6.1
-      protobufjs: 7.5.4
+      firebase-admin: 13.10.0
+      protobufjs: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   form-data@2.5.5:
     dependencies:
@@ -5508,6 +4707,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
       safe-buffer: 5.2.1
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -5532,6 +4735,14 @@ snapshots:
       - encoding
       - supports-color
 
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1:
     dependencies:
       gaxios: 6.7.1
@@ -5539,6 +4750,14 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
@@ -5569,7 +4788,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.1.0
+      basic-ftp: 6.0.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -5579,9 +4798,18 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regexp@0.4.1: {}
-
   globals@14.0.0: {}
+
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   google-auth-library@9.15.1:
     dependencies:
@@ -5606,7 +4834,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.2
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -5615,6 +4843,8 @@ snapshots:
     optional: true
 
   google-logging-utils@0.0.2: {}
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -5712,8 +4942,6 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
-
-  is-arrayish@0.3.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -5882,8 +5110,6 @@ snapshots:
 
   long@5.3.2: {}
 
-  loupe@3.2.1: {}
-
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5921,43 +5147,21 @@ snapshots:
 
   mime@3.0.0: {}
 
-  miniflare@4.20250906.0:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.14.0
-      acorn-walk: 8.3.2
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      sharp: 0.33.5
-      stoppable: 1.1.0
-      undici: 7.18.2
-      workerd: 1.20250906.0
-      ws: 8.18.0
-      youch: 4.1.0-beta.10
-      zod: 3.22.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  miniflare@4.20260212.0:
+  miniflare@4.20260609.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
-      workerd: 1.20260212.0
-      ws: 8.18.0
+      undici: 8.4.1
+      workerd: 1.20260609.1
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  minimatch@3.1.2:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.6
 
   ms@2.0.0: {}
 
@@ -5971,11 +5175,17 @@ snapshots:
 
   netmask@2.0.2: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-forge@1.3.3: {}
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.44: {}
 
@@ -5990,7 +5200,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  ohash@2.0.11: {}
+  obug@2.1.2: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -6043,23 +5253,19 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-key@3.1.1: {}
+  path-expression-matcher@1.5.0: {}
 
-  path-to-regexp@0.1.12: {}
+  path-key@3.1.1: {}
 
   path-to-regexp@6.3.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss@8.5.6:
     dependencies:
@@ -6075,21 +5281,21 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 7.6.2
     optional: true
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.2:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.7
       long: 5.3.2
 
@@ -6171,35 +5377,35 @@ snapshots:
 
   retry@0.13.1: {}
 
-  rollup@4.57.1:
+  rollup@4.61.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
   rxjs@7.8.2:
@@ -6247,32 +5453,6 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.1.2
-      semver: 7.7.3
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
@@ -6310,7 +5490,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -6342,10 +5522,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
-
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
@@ -6370,9 +5546,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
-
-  stoppable@1.1.0: {}
+  std-env@4.1.0: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -6405,7 +5579,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.1.2: {}
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
 
   stubs@3.0.0: {}
 
@@ -6465,18 +5641,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@1.2.0: {}
-
-  tinyspy@3.0.2: {}
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -6484,7 +5656,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
@@ -6501,8 +5673,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ufo@1.6.3: {}
-
   uhyphen@0.2.0: {}
 
   unbzip2-stream@1.4.3:
@@ -6512,15 +5682,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.18.2: {}
-
-  unenv@2.0.0-rc.21:
-    dependencies:
-      defu: 6.1.4
-      exsolve: 1.0.8
-      ohash: 2.0.11
-      pathe: 2.0.3
-      ufo: 1.6.3
+  undici@8.4.1: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -6542,49 +5704,19 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
-
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
-  vite-node@2.1.9(@types/node@22.19.7)(lightningcss@1.32.0):
+  vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.19.7)(lightningcss@1.32.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.21(@types/node@22.19.7)(lightningcss@1.32.0):
-    dependencies:
-      esbuild: 0.21.5
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
-      rollup: 4.57.1
-    optionalDependencies:
-      '@types/node': 22.19.7
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-
-  vite@6.4.2(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0):
-    dependencies:
-      esbuild: 0.25.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
+      rollup: 4.61.1
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.7
@@ -6592,40 +5724,35 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@2.1.9(@types/node@22.19.7)(lightningcss@1.32.0):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.7)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.19.7)(lightningcss@1.32.0)
-      vite-node: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.7
     transitivePeerDependencies:
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -6653,50 +5780,26 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20250906.0:
+  workerd@1.20260609.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250906.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250906.0
-      '@cloudflare/workerd-linux-64': 1.20250906.0
-      '@cloudflare/workerd-linux-arm64': 1.20250906.0
-      '@cloudflare/workerd-windows-64': 1.20250906.0
+      '@cloudflare/workerd-darwin-64': 1.20260609.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260609.1
+      '@cloudflare/workerd-linux-64': 1.20260609.1
+      '@cloudflare/workerd-linux-arm64': 1.20260609.1
+      '@cloudflare/workerd-windows-64': 1.20260609.1
 
-  workerd@1.20260212.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260212.0
-      '@cloudflare/workerd-darwin-arm64': 1.20260212.0
-      '@cloudflare/workerd-linux-64': 1.20260212.0
-      '@cloudflare/workerd-linux-arm64': 1.20260212.0
-      '@cloudflare/workerd-windows-64': 1.20260212.0
-
-  wrangler@4.35.0(@cloudflare/workers-types@4.20260130.0):
+  wrangler@4.99.0(@cloudflare/workers-types@4.20260609.1):
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.0
-      '@cloudflare/unenv-preset': 2.7.3(unenv@2.0.0-rc.21)(workerd@1.20250906.0)
-      blake3-wasm: 2.1.5
-      esbuild: 0.25.4
-      miniflare: 4.20250906.0
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.21
-      workerd: 1.20250906.0
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260130.0
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.65.0:
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260212.0
+      miniflare: 4.20260609.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260212.0
+      workerd: 1.20260609.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260609.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -6711,6 +5814,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  ws@8.20.1: {}
+
+  xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
 
@@ -6750,4 +5857,4 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
-  zod@3.22.3: {}
+  zod@3.25.76: {}

--- a/warg/pnpm-lock.yaml
+++ b/warg/pnpm-lock.yaml
@@ -72,6 +72,22 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  cloud-functions/backfill-scripts:
+    dependencies:
+      firebase-admin:
+        specifier: ^13.0.2
+        version: 13.6.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.7
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.7)(lightningcss@1.32.0)
+
   cloud-functions/dashboard-api:
     dependencies:
       '@google-cloud/storage':

--- a/warg/pnpm-lock.yaml
+++ b/warg/pnpm-lock.yaml
@@ -28,24 +28,24 @@ importers:
       '@cloudflare/puppeteer':
         specifier: ^1.0.5
         version: 1.0.5
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.61.0
-        version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.61.0
-        version: 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.61.0
+        version: 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       wrangler:
         specifier: ^4.99.0
         version: 4.99.0(@cloudflare/workers-types@4.20260609.1)
@@ -1994,6 +1994,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+    engines: {node: '>=18'}
+
   google-auth-library@10.7.0:
     resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
     engines: {node: '>=18'}
@@ -2800,6 +2804,13 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  typescript-eslint@8.61.0:
+    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -4800,6 +4811,8 @@ snapshots:
 
   globals@14.0.0: {}
 
+  globals@17.6.0: {}
+
   google-auth-library@10.7.0:
     dependencies:
       base64-js: 1.5.1
@@ -5670,6 +5683,17 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  typescript-eslint@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 

--- a/warg/scripts/analyze-short-ids.mjs
+++ b/warg/scripts/analyze-short-ids.mjs
@@ -13,9 +13,9 @@ const lines = readFileSync(
 
 const header = lines[0].split(',');
 const COL = (name) => header.indexOf(name);
-const iResolved = COL('resolved_id');
-const iStatus = COL('status');
-const iDomain = COL('domain');
+const _iResolved = COL('resolved_id');
+const _iStatus = COL('status');
+const _iDomain = COL('domain');
 
 let total = 0, unanchored = 0;
 const shortRows = [];               // unblocked by fix (1-7 char safe id, not UUID)

--- a/warg/scripts/reconcile-archives-map.mjs
+++ b/warg/scripts/reconcile-archives-map.mjs
@@ -26,7 +26,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PROJECT = 'trails-e428e';
-const GCS_PROJECT = 'trails-414917';
+const _GCS_PROJECT = 'trails-414917';
 const BUCKET = 'htbase-archives-standard';
 const DB = `projects/${PROJECT}/databases/(default)`;
 const DOC_PREFIX = `${DB}/documents`;

--- a/warg/workers/gateway/package.json
+++ b/warg/workers/gateway/package.json
@@ -14,6 +14,6 @@
     "@warg/shared": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/gateway/src/container-sweep.test.ts
+++ b/warg/workers/gateway/src/container-sweep.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { sweepOrphanContainers } from './index.js';
+import { sweepOrphanContainers, CONTAINER_SWEEP_MIN_LEASE_AGE_MS } from './index.js';
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -110,5 +110,46 @@ describe('sweepOrphanContainers', () => {
     const { env } = createEnv(jsonResponse({ error: 'nope' }, 503));
 
     await expect(sweepOrphanContainers(env, 'test')).rejects.toThrow(/sandbox-leases fetch failed/);
+  });
+
+  it('attempts all stale leases and isolates per-container failures', async () => {
+    // Two stale leases; first stop responds 500, second responds ok.
+    // Both stops must be attempted and only the first failure is recorded.
+    const monolithFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: 'internal error' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const workflowFetch = vi.fn(async () =>
+      jsonResponse({
+        leases: [
+          { leaseId: 'l1', requestId: 'req-fail', acquiredAt: Date.now() - STALE_MS },
+          { leaseId: 'l2', requestId: 'req-ok', acquiredAt: Date.now() - STALE_MS }
+        ]
+      })
+    );
+    const env = {
+      INTERNAL_API_KEY: 'internal-key',
+      WORKFLOW: { fetch: workflowFetch } as unknown as Fetcher,
+      MONOLITH: { fetch: monolithFetch } as unknown as Fetcher
+    } as Env;
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    // Both containers were attempted
+    expect(monolithFetch).toHaveBeenCalledTimes(2);
+    expect(summary.stale).toBe(2);
+    expect(summary.stopped).toBe(1);
+    expect(summary.failures).toHaveLength(1);
+    // The first lease (req-fail) is the only failure
+    expect(summary.failures[0]?.requestId).toBe('req-fail');
+    expect(summary.failures[0]?.error).toContain('500');
+  });
+});
+
+describe('CONTAINER_SWEEP_MIN_LEASE_AGE_MS', () => {
+  it('equals 5 * 60 * 1000 — must stay in sync with LEASE_TTL_MS in warg/workers/workflow/src/BrowserQuotaDO.ts', () => {
+    // Tripwire: if this constant drifts from BrowserQuotaDO.LEASE_TTL_MS the
+    // sweep will either kill valid leases (too low) or miss orphans (too high).
+    expect(CONTAINER_SWEEP_MIN_LEASE_AGE_MS).toBe(5 * 60 * 1000);
   });
 });

--- a/warg/workers/gateway/src/container-sweep.test.ts
+++ b/warg/workers/gateway/src/container-sweep.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sweepOrphanContainers } from './index.js';
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+const STALE_MS = 6 * 60 * 1000; // older than the 5-minute lease TTL
+const FRESH_MS = 60 * 1000;
+
+function createEnv(leasesResponse: Response, stopResponse?: Response) {
+  const workflowFetch = vi.fn(async () => leasesResponse);
+  const monolithFetch = vi.fn(async () => stopResponse ?? jsonResponse({ ok: true }));
+  const env = {
+    INTERNAL_API_KEY: 'internal-key',
+    WORKFLOW: { fetch: workflowFetch } as unknown as Fetcher,
+    MONOLITH: { fetch: monolithFetch } as unknown as Fetcher
+  } as Env;
+  return { env, workflowFetch, monolithFetch };
+}
+
+describe('sweepOrphanContainers', () => {
+  it('does nothing when there are no sandbox leases', async () => {
+    const { env, monolithFetch } = createEnv(jsonResponse({ leases: [] }));
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    expect(summary).toEqual({ source: 'test', leases: 0, stale: 0, stopped: 0, failures: [] });
+    expect(monolithFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips fresh leases (jobs still inside their lease window)', async () => {
+    const { env, monolithFetch } = createEnv(
+      jsonResponse({
+        leases: [{ leaseId: 'l1', requestId: 'req-fresh', acquiredAt: Date.now() - FRESH_MS }]
+      })
+    );
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    expect(summary.leases).toBe(1);
+    expect(summary.stale).toBe(0);
+    expect(monolithFetch).not.toHaveBeenCalled();
+  });
+
+  it('stops containers for stale leases via the monolith worker', async () => {
+    const { env, workflowFetch, monolithFetch } = createEnv(
+      jsonResponse({
+        leases: [
+          { leaseId: 'l1', requestId: 'req-stale', acquiredAt: Date.now() - STALE_MS },
+          { leaseId: 'l2', requestId: 'req-fresh', acquiredAt: Date.now() - FRESH_MS }
+        ]
+      })
+    );
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    expect(summary).toEqual({ source: 'test', leases: 2, stale: 1, stopped: 1, failures: [] });
+
+    expect(workflowFetch).toHaveBeenCalledWith(
+      'https://workflow/browser-quota/sandbox-leases',
+      expect.objectContaining({ headers: { 'X-Internal-API-Key': 'internal-key' } })
+    );
+
+    expect(monolithFetch).toHaveBeenCalledTimes(1);
+    const [stopUrl, stopInit] = monolithFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(stopUrl).toBe('https://monolith/container/stop');
+    expect(JSON.parse(String(stopInit.body))).toEqual({ request_id: 'req-stale' });
+    expect((stopInit.headers as Record<string, string>)['X-Internal-API-Key']).toBe('internal-key');
+  });
+
+  it('records a failure when the stop call is rejected, without throwing', async () => {
+    const { env } = createEnv(
+      jsonResponse({
+        leases: [{ leaseId: 'l1', requestId: 'req-stale', acquiredAt: Date.now() - STALE_MS }]
+      }),
+      jsonResponse({ error: 'boom' }, 500)
+    );
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    expect(summary.stale).toBe(1);
+    expect(summary.stopped).toBe(0);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0]?.requestId).toBe('req-stale');
+    expect(summary.failures[0]?.error).toContain('500');
+  });
+
+  it('ignores malformed lease rows', async () => {
+    const { env, monolithFetch } = createEnv(
+      jsonResponse({
+        leases: [
+          { leaseId: 'l1', acquiredAt: Date.now() - STALE_MS }, // no requestId
+          { leaseId: 'l2', requestId: 'req-no-ts' } // no acquiredAt
+        ]
+      })
+    );
+
+    const summary = await sweepOrphanContainers(env, 'test');
+
+    expect(summary.leases).toBe(2);
+    expect(summary.stale).toBe(0);
+    expect(monolithFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when the lease listing itself fails', async () => {
+    const { env } = createEnv(jsonResponse({ error: 'nope' }, 503));
+
+    await expect(sweepOrphanContainers(env, 'test')).rejects.toThrow(/sandbox-leases fetch failed/);
+  });
+});

--- a/warg/workers/gateway/src/env.d.ts
+++ b/warg/workers/gateway/src/env.d.ts
@@ -1,4 +1,5 @@
 interface Env {
   INTERNAL_API_KEY: string;
   PUBLIC_API_KEY: string;
+  MONOLITH: Fetcher;
 }

--- a/warg/workers/gateway/src/index.ts
+++ b/warg/workers/gateway/src/index.ts
@@ -424,8 +424,21 @@ export async function sweepOrphanContainers(
     throw new Error(`sandbox-leases fetch failed (${response.status}): ${body}`);
   }
 
-  const payload = (await response.json()) as { leases?: SandboxLeaseRow[] };
-  const leases = payload.leases ?? [];
+  const raw: unknown = await response.json();
+  if (
+    raw === null ||
+    typeof raw !== 'object' ||
+    !Array.isArray((raw as Record<string, unknown>)['leases'])
+  ) {
+    console.warn('[gateway] container sweep: unexpected sandbox-leases payload shape, skipping', JSON.stringify(raw)?.slice(0, 300));
+    return summary;
+  }
+  const leases = (raw as { leases: unknown[] }).leases.filter(
+    (entry): entry is SandboxLeaseRow =>
+      entry !== null &&
+      typeof entry === 'object' &&
+      ('requestId' in entry || 'acquiredAt' in entry)
+  );
   summary.leases = leases.length;
 
   const now = Date.now();

--- a/warg/workers/gateway/src/index.ts
+++ b/warg/workers/gateway/src/index.ts
@@ -17,8 +17,14 @@ const ORPHAN_SWEEP_DEFAULT_MIN_AGE_MS = 10 * 60 * 1000;
 const ORPHAN_SWEEP_WORKFLOW_ATTEMPTS = 2;
 // Leases older than this had their job finish long ago (P99 monolith wall time
 // is ~3 min) — the workflow likely crashed before release(), so the container
-// behind the lease may still be running. Matches BrowserQuotaDO.LEASE_TTL_MS.
-const CONTAINER_SWEEP_MIN_LEASE_AGE_MS = 5 * 60 * 1000;
+// behind the lease may still be running.
+// MUST be kept in sync with `LEASE_TTL_MS` in
+// `warg/workers/workflow/src/BrowserQuotaDO.ts`.
+// If this value is LOWER than LEASE_TTL_MS: sweep will stop containers under
+// still-valid leases (premature kill).
+// If this value is HIGHER than LEASE_TTL_MS: orphaned containers are missed
+// until the excess gap elapses (delayed cleanup).
+export const CONTAINER_SWEEP_MIN_LEASE_AGE_MS = 5 * 60 * 1000;
 
 interface LoggerRequestRow {
   requestId?: string;
@@ -393,7 +399,7 @@ export interface ContainerSweepResult {
 /**
  * Stop monolith containers whose quota lease outlived the TTL — the third
  * lifecycle layer after the monolith worker's per-job stop() and the Sandbox
- * class's 30s sleepAfter backstop. Lists active sandbox leases from the
+ * class's 5m sleepAfter backstop. Lists active sandbox leases from the
  * workflow worker and asks the monolith worker to stop each stale lease's
  * container. Best-effort: per-container failures are reported, not thrown.
  */
@@ -410,7 +416,8 @@ export async function sweepOrphanContainers(
   };
 
   const response = await env.WORKFLOW.fetch('https://workflow/browser-quota/sandbox-leases', {
-    headers: { 'X-Internal-API-Key': env.INTERNAL_API_KEY }
+    headers: { 'X-Internal-API-Key': env.INTERNAL_API_KEY },
+    signal: AbortSignal.timeout(10_000)
   });
   if (!response.ok) {
     const body = (await response.text()).slice(0, 300);
@@ -434,7 +441,8 @@ export async function sweepOrphanContainers(
           'Content-Type': 'application/json',
           'X-Internal-API-Key': env.INTERNAL_API_KEY
         },
-        body: JSON.stringify({ request_id: lease.requestId })
+        body: JSON.stringify({ request_id: lease.requestId }),
+        signal: AbortSignal.timeout(10_000)
       });
       if (stopResponse.ok) {
         summary.stopped += 1;
@@ -693,8 +701,10 @@ export default {
       (async () => {
         try {
           const summary = await sweepOrphanContainers(env, `cron:${controller.cron ?? 'unknown'}`);
-          if (summary.stale > 0 || summary.failures.length > 0) {
-            console.log('[gateway] container sweep summary:', JSON.stringify(summary));
+          if (summary.failures.length > 0) {
+            console.error('[gateway] container sweep partial failures:', JSON.stringify(summary));
+          } else {
+            console.log('[gateway] container sweep done:', JSON.stringify({ leases: summary.leases, stale: summary.stale, stopped: summary.stopped }));
           }
         } catch (err) {
           console.error('[gateway] container sweep failed:', err);

--- a/warg/workers/gateway/src/index.ts
+++ b/warg/workers/gateway/src/index.ts
@@ -15,6 +15,10 @@ const LOGGER_RETRY_ATTEMPTS = 3;
 const ORPHAN_SWEEP_DEFAULT_LIMIT = 100;
 const ORPHAN_SWEEP_DEFAULT_MIN_AGE_MS = 10 * 60 * 1000;
 const ORPHAN_SWEEP_WORKFLOW_ATTEMPTS = 2;
+// Leases older than this had their job finish long ago (P99 monolith wall time
+// is ~3 min) — the workflow likely crashed before release(), so the container
+// behind the lease may still be running. Matches BrowserQuotaDO.LEASE_TTL_MS.
+const CONTAINER_SWEEP_MIN_LEASE_AGE_MS = 5 * 60 * 1000;
 
 interface LoggerRequestRow {
   requestId?: string;
@@ -372,6 +376,86 @@ async function sweepQueuedOrphans(
   return summary;
 }
 
+interface SandboxLeaseRow {
+  leaseId?: string;
+  requestId?: string;
+  acquiredAt?: number;
+}
+
+export interface ContainerSweepResult {
+  source: string;
+  leases: number;
+  stale: number;
+  stopped: number;
+  failures: Array<{ requestId: string; error: string }>;
+}
+
+/**
+ * Stop monolith containers whose quota lease outlived the TTL — the third
+ * lifecycle layer after the monolith worker's per-job stop() and the Sandbox
+ * class's 30s sleepAfter backstop. Lists active sandbox leases from the
+ * workflow worker and asks the monolith worker to stop each stale lease's
+ * container. Best-effort: per-container failures are reported, not thrown.
+ */
+export async function sweepOrphanContainers(
+  env: Env,
+  source: string
+): Promise<ContainerSweepResult> {
+  const summary: ContainerSweepResult = {
+    source,
+    leases: 0,
+    stale: 0,
+    stopped: 0,
+    failures: []
+  };
+
+  const response = await env.WORKFLOW.fetch('https://workflow/browser-quota/sandbox-leases', {
+    headers: { 'X-Internal-API-Key': env.INTERNAL_API_KEY }
+  });
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 300);
+    throw new Error(`sandbox-leases fetch failed (${response.status}): ${body}`);
+  }
+
+  const payload = (await response.json()) as { leases?: SandboxLeaseRow[] };
+  const leases = payload.leases ?? [];
+  summary.leases = leases.length;
+
+  const now = Date.now();
+  for (const lease of leases) {
+    if (!lease.requestId || typeof lease.acquiredAt !== 'number') continue;
+    if (now - lease.acquiredAt < CONTAINER_SWEEP_MIN_LEASE_AGE_MS) continue;
+    summary.stale += 1;
+
+    try {
+      const stopResponse = await env.MONOLITH.fetch('https://monolith/container/stop', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-API-Key': env.INTERNAL_API_KEY
+        },
+        body: JSON.stringify({ request_id: lease.requestId })
+      });
+      if (stopResponse.ok) {
+        summary.stopped += 1;
+      } else {
+        const body = (await stopResponse.text()).slice(0, 300);
+        summary.failures.push({
+          requestId: lease.requestId,
+          error: `stop failed (${stopResponse.status}): ${body}`
+        });
+      }
+    } catch (err) {
+      summary.failures.push({
+        requestId: lease.requestId,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }
+
+  return summary;
+}
+
 export default {
   async fetch(
     request: Request,
@@ -602,6 +686,18 @@ export default {
           }
         } catch (err) {
           console.error('[gateway] orphan sweep failed:', err);
+        }
+      })()
+    );
+    ctx.waitUntil(
+      (async () => {
+        try {
+          const summary = await sweepOrphanContainers(env, `cron:${controller.cron ?? 'unknown'}`);
+          if (summary.stale > 0 || summary.failures.length > 0) {
+            console.log('[gateway] container sweep summary:', JSON.stringify(summary));
+          }
+        } catch (err) {
+          console.error('[gateway] container sweep failed:', err);
         }
       })()
     );

--- a/warg/workers/gateway/wrangler.jsonc
+++ b/warg/workers/gateway/wrangler.jsonc
@@ -5,7 +5,8 @@
   "compatibility_date": "2025-01-01",
   "services": [
     { "binding": "LOGGER", "service": "logger" },
-    { "binding": "WORKFLOW", "service": "workflow" }
+    { "binding": "WORKFLOW", "service": "workflow" },
+    { "binding": "MONOLITH", "service": "monolith" }
   ],
   "triggers": {
     "crons": ["*/10 * * * *"]

--- a/warg/workers/gateway/wrangler.jsonc
+++ b/warg/workers/gateway/wrangler.jsonc
@@ -14,5 +14,12 @@
   "r2_buckets": [
     { "binding": "ARCHIVE_BUCKET", "bucket_name": "warg-archives" }
   ],
-  "observability": { "enabled": true }
+  "observability": { "enabled": true },
+  // Deploy order: gateway must deploy AFTER monolith and workflow so its
+  // service-binding targets exist (see scripts/deploy.sh Tier 3).
+
+  // Secrets (via `wrangler secret put`):
+  // - INTERNAL_API_KEY: shared key for internal service auth (sweeps, event
+  //   forwarding to logger/workflow); used on all internal sub-request calls
+  // - PUBLIC_API_KEY: external client auth on POST /begin and GET /status/:id
 }

--- a/warg/workers/gcs/package.json
+++ b/warg/workers/gcs/package.json
@@ -14,6 +14,6 @@
     "@warg/shared": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/hyperrenderer/package.json
+++ b/warg/workers/hyperrenderer/package.json
@@ -14,6 +14,6 @@
     "@warg/shared": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/hyperrenderer/src/payload-decode.test.ts
+++ b/warg/workers/hyperrenderer/src/payload-decode.test.ts
@@ -7,14 +7,13 @@ function toText(data: ArrayBuffer): string {
 
 describe('decodeBase64ToArrayBuffer', () => {
   it('decodes standard base64 payload', () => {
-    const encoded = Buffer.from('hello world', 'utf8').toString('base64');
+    const encoded = btoa('hello world');
     const decoded = decodeBase64ToArrayBuffer(encoded);
     expect(toText(decoded)).toBe('hello world');
   });
 
   it('decodes url-safe base64 payload', () => {
-    const encoded = Buffer.from('hello_world', 'utf8')
-      .toString('base64')
+    const encoded = btoa('hello_world')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/g, '');
@@ -26,7 +25,7 @@ describe('decodeBase64ToArrayBuffer', () => {
 
 describe('decodeBinaryPayload', () => {
   it('decodes data URL payloads', async () => {
-    const encoded = Buffer.from('test-data', 'utf8').toString('base64');
+    const encoded = btoa('test-data');
     const decoded = await decodeBinaryPayload(`data:image/png;base64,${encoded}`);
 
     expect(decoded.source).toBe('data_url');
@@ -35,7 +34,7 @@ describe('decodeBinaryPayload', () => {
   });
 
   it('decodes raw base64 payloads', async () => {
-    const encoded = Buffer.from('raw-base64', 'utf8').toString('base64');
+    const encoded = btoa('raw-base64');
     const decoded = await decodeBinaryPayload(encoded);
 
     expect(decoded.source).toBe('base64');

--- a/warg/workers/logger/README.md
+++ b/warg/workers/logger/README.md
@@ -1,0 +1,63 @@
+# logger
+
+Event-sourced request traces. Internal worker (service-bound, `X-Internal-API-Key`
+on every route). Authoritative store is SQLite inside Durable Objects; the D1
+`requests_index` table is a derived index for list/stats reads.
+
+## Durable Object keying: hour buckets
+
+`LoggerDO` instances are keyed by UTC hour: `bucket:YYYYMMDDHH`
+(`bucketKeyForTs` in `src/index.ts`). Every request initialized in that hour
+lives in the same instance — roughly 24 warm instances per day instead of one
+cold-started instance per request. Rationale and cost numbers:
+[`docs/adr-do-cost.md`](../../docs/adr-do-cost.md).
+
+A request belongs to the bucket of its `created_at` hour, fixed at init time:
+`POST /request/init` derives the bucket key and the stored `created_at` from
+the same timestamp, so they can never disagree across an hour boundary.
+
+### Routing
+
+- **Writes after init** (`POST /event`, `POST /artifact`): look up
+  `requests_index.created_at` in D1, derive the bucket, write there. If D1
+  has no row (its best-effort insert failed), the write falls back to the
+  current-hour bucket rather than being dropped.
+- **Reads** (`GET /request/:id`, `/events`, `/stream`): same D1-derived
+  bucket first; if the bucket returns no row for the request id, fall back to
+  the **legacy per-request instance** (`idFromName(requestId)`, the
+  pre-bucket scheme). No backfill is performed — old traces stay where they
+  are and remain readable.
+- **`PATCH /request/:id`**: bucket first, then legacy — the only write path
+  allowed to touch a legacy instance, so requests mid-flight at cutover can
+  still record their manifest key.
+
+### Schema
+
+`events` and `artifacts` carry a `request_id` column (indexed); all DO
+methods take the request id and filter on it. `migrateSchema` (run from
+`ensureSchema` on every instance start) upgrades legacy instances in place:
+adds the columns and adopts existing rows under the instance's single
+request. It is idempotent.
+
+## Endpoints
+
+| Route | Notes |
+|---|---|
+| `POST /request/init` | creates request row + D1 index row |
+| `POST /event` | appends event, replays derived summary |
+| `POST /artifact` | upserts artifact metadata |
+| `PATCH /request/:id` | manifest key / external json |
+| `GET /request/:id` | canonical view (dual-read) |
+| `GET /request/:id/events` | paginated events (dual-read) |
+| `GET /request/:id/stream` | SSE, 3s poll, 2-minute cap (dual-read) |
+| `GET /requests`, `GET /stats`, `POST /requests/batch` | served from D1 index |
+| `POST /maintenance/backfill-diagnostics` | recompute legacy diagnostics (dual-read) |
+
+## Tests
+
+```bash
+pnpm --filter @warg/logger test
+```
+
+Runs under `@cloudflare/vitest-pool-workers` with real DO instances,
+including bucket multi-request isolation and the legacy-instance migration.

--- a/warg/workers/logger/README.md
+++ b/warg/workers/logger/README.md
@@ -7,7 +7,7 @@ on every route). Authoritative store is SQLite inside Durable Objects; the D1
 ## Durable Object keying: hour buckets
 
 `LoggerDO` instances are keyed by UTC hour: `bucket:YYYYMMDDHH`
-(`bucketKeyForTs` in `src/index.ts`). Every request initialized in that hour
+(`bucketKeyForTs` in `src/bucket-key.ts`). Every request initialized in that hour
 lives in the same instance — roughly 24 warm instances per day instead of one
 cold-started instance per request. Rationale and cost numbers:
 [`docs/adr-do-cost.md`](../../docs/adr-do-cost.md).

--- a/warg/workers/logger/README.md
+++ b/warg/workers/logger/README.md
@@ -18,10 +18,11 @@ the same timestamp, so they can never disagree across an hour boundary.
 
 ### Routing
 
-- **Writes after init** (`POST /event`, `POST /artifact`): look up
-  `requests_index.created_at` in D1, derive the bucket, write there. If D1
-  has no row (its best-effort insert failed), the write falls back to the
-  current-hour bucket rather than being dropped.
+- **Writes after init** (`POST /event`, `POST /events/batch`, `POST /artifact`):
+  look up `requests_index.created_at` in D1, derive the bucket, write there.
+  If D1 has no row (its best-effort insert failed), the write falls back to the
+  current-hour bucket rather than being dropped — a data-locality trade-off
+  accepted over event loss.
 - **Reads** (`GET /request/:id`, `/events`, `/stream`): same D1-derived
   bucket first; if the bucket returns no row for the request id, fall back to
   the **legacy per-request instance** (`idFromName(requestId)`, the
@@ -44,11 +45,12 @@ request. It is idempotent.
 | Route | Notes |
 |---|---|
 | `POST /request/init` | creates request row + D1 index row |
-| `POST /event` | appends event, replays derived summary |
+| `POST /event` | appends a single event, replays derived summary |
+| `POST /events/batch` | atomically appends up to 100 events in one DO round-trip; body `{ requestId, events[] }`; returns `{ eventIds, derivedUpdated }`; terminal events are sent per-event by design |
 | `POST /artifact` | upserts artifact metadata |
-| `PATCH /request/:id` | manifest key / external json |
-| `GET /request/:id` | canonical view (dual-read) |
-| `GET /request/:id/events` | paginated events (dual-read) |
+| `PATCH /request/:id` | manifest key / external json; returns **404** for unknown request ids |
+| `GET /request/:id` | canonical view (dual-read); returns **404** for unknown request ids |
+| `GET /request/:id/events` | paginated events (dual-read); returns **200 `{ events: [] }`** for unknown ids (intentional historical wire shape — `GET /request/:id` is the authoritative existence check) |
 | `GET /request/:id/stream` | SSE, 3s poll, 2-minute cap (dual-read) |
 | `GET /requests`, `GET /stats`, `POST /requests/batch` | served from D1 index |
 | `POST /maintenance/backfill-diagnostics` | recompute legacy diagnostics (dual-read) |

--- a/warg/workers/logger/package.json
+++ b/warg/workers/logger/package.json
@@ -15,8 +15,8 @@
     "@warg/shared": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.8.1",
-    "@cloudflare/workers-types": "^4.20250123.0",
-    "vitest": "^2.1.8"
+    "@cloudflare/vitest-pool-workers": "^0.16.14",
+    "@cloudflare/workers-types": "^4.20260609.1",
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/logger/src/LoggerDO.test.ts
+++ b/warg/workers/logger/src/LoggerDO.test.ts
@@ -1,4 +1,4 @@
-import { env, runInDurableObject } from 'cloudflare:test';
+import { env, runInDurableObject, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import type {
   InitRequestPayload,
@@ -22,9 +22,9 @@ interface LoggerEventWithId {
 }
 
 interface LoggerStub {
-  initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
+  initRequest(payload: InitRequestPayload, createdAt: string): Promise<{ created: boolean }>;
   appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
-  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }>;
+  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[]; derivedUpdated: boolean }>;
   upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
   updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
   getRequestView(
@@ -85,7 +85,7 @@ describe('LoggerDO', () => {
         requestId,
         url: 'https://example.com/page',
         optionsR2Key: 'archives/test/input/options.json'
-      });
+      }, new Date().toISOString());
 
       expect(result.created).toBe(true);
     });
@@ -99,8 +99,9 @@ describe('LoggerDO', () => {
         url: 'https://example.com/page'
       };
 
-      const first = await stub.initRequest(payload);
-      const second = await stub.initRequest(payload);
+      const nowIso = new Date().toISOString();
+      const first = await stub.initRequest(payload, nowIso);
+      const second = await stub.initRequest(payload, nowIso);
 
       expect(first.created).toBe(true);
       expect(second.created).toBe(false);
@@ -124,8 +125,9 @@ describe('LoggerDO', () => {
       const reqA = `bucket-test-${Date.now()}-a`;
       const reqB = `bucket-test-${Date.now()}-b`;
 
-      await stub.initRequest({ requestId: reqA, url: 'https://example.com/a' });
-      await stub.initRequest({ requestId: reqB, url: 'https://example.com/b' });
+      const nowIsoA = new Date().toISOString();
+      await stub.initRequest({ requestId: reqA, url: 'https://example.com/a' }, nowIsoA);
+      await stub.initRequest({ requestId: reqB, url: 'https://example.com/b' }, nowIsoA);
 
       await stub.appendEvent(reqA, infoEvent('step.started', 'Render A', { step: 'render' }));
       await stub.appendEvent(reqA, {
@@ -266,7 +268,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-3`;
       const stub = getStub('bucket:2026060911');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const event: LogEvent = {
         ts: new Date().toISOString(),
@@ -284,7 +286,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-4`;
       const stub = getStub('bucket:2026060911');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const errorEvent: LogEvent = {
         ts: new Date().toISOString(),
@@ -305,7 +307,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5`;
       const stub = getStub('bucket:2026060911');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       {
         const view1 = await stub.getRequestView(requestId);
@@ -374,7 +376,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5b`;
       const stub = getStub('bucket:2026060912');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -458,7 +460,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5c-incomplete`;
       const stub = getStub('bucket:2026060912');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -483,7 +485,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5c`;
       const stub = getStub('bucket:2026060912');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -533,7 +535,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5d`;
       const stub = getStub('bucket:2026060913');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -552,7 +554,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5e`;
       const stub = getStub('bucket:2026060913');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -580,7 +582,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-5f`;
       const stub = getStub('bucket:2026060913');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -605,10 +607,11 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-be`;
       const stub = getStub('bucket:2026061010');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const result = await stub.appendEvents(requestId, []);
       expect(result.eventIds).toEqual([]);
+      expect(result.derivedUpdated).toBe(false);
 
       const view = await stub.getRequestView(requestId);
       expect(view?.events).toHaveLength(0);
@@ -619,9 +622,10 @@ describe('LoggerDO', () => {
       const seqId = `test-${Date.now()}-bs`;
       const batchId = `test-${Date.now()}-bb`;
       const stub = getStub('bucket:2026061011');
+      const nowIsoBatch1 = new Date().toISOString();
 
-      await stub.initRequest({ requestId: seqId, url: 'https://example.com' });
-      await stub.initRequest({ requestId: batchId, url: 'https://example.com' });
+      await stub.initRequest({ requestId: seqId, url: 'https://example.com' }, nowIsoBatch1);
+      await stub.initRequest({ requestId: batchId, url: 'https://example.com' }, nowIsoBatch1);
 
       // Same event objects replayed both ways, so ts values match exactly
       const events: LogEvent[] = [
@@ -643,6 +647,7 @@ describe('LoggerDO', () => {
       const result = await stub.appendEvents(batchId, events);
 
       expect(result.eventIds).toHaveLength(events.length);
+      expect(result.derivedUpdated).toBe(true);
 
       const seqView = await stub.getRequestView(seqId);
       const batchView = await stub.getRequestView(batchId);
@@ -656,7 +661,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-bt`;
       const stub = getStub('bucket:2026061012');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       await stub.appendEvents(requestId, [
         infoEvent('step.started', 'Renderer step started', { step: 'render' }),
@@ -672,7 +677,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-bk`;
       const stub = getStub('bucket:2026061013');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       // step.completed maps to no stage, so the sequential state machine
       // leaves the terminal 'done' untouched — the batch replay must too
@@ -690,7 +695,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-ba`;
       const stub = getStub('bucket:2026061014');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const result = await stub.appendEvents(requestId, [
         infoEvent('artifact.written', 'Artifact written: rendered.html', {
@@ -710,6 +715,7 @@ describe('LoggerDO', () => {
       ]);
 
       expect(result.eventIds).toHaveLength(2);
+      expect(result.derivedUpdated).toBe(true);
 
       const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(2);
@@ -721,9 +727,10 @@ describe('LoggerDO', () => {
       const seqId = `test-${Date.now()}-bcs`;
       const batchId = `test-${Date.now()}-bcb`;
       const stub = getStub('bucket:2026061015');
+      const nowIsoBatch2 = new Date().toISOString();
 
-      await stub.initRequest({ requestId: seqId, url: 'https://example.com' });
-      await stub.initRequest({ requestId: batchId, url: 'https://example.com' });
+      await stub.initRequest({ requestId: seqId, url: 'https://example.com' }, nowIsoBatch2);
+      await stub.initRequest({ requestId: batchId, url: 'https://example.com' }, nowIsoBatch2);
 
       const events: LogEvent[] = [
         infoEvent('workflow.started', 'Workflow started'),
@@ -781,7 +788,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-6`;
       const stub = getStub('bucket:2026060916');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const artifact: ArtifactRecord = {
         kind: 'rendered.html',
@@ -803,7 +810,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-7`;
       const stub = getStub('bucket:2026060916');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const artifact1: ArtifactRecord = {
         kind: 'rendered.html',
@@ -836,7 +843,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-8`;
       const stub = getStub('bucket:2026060917');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const result = await stub.updateRequestFields(requestId, {
         manifestR2Key: `archives/${requestId}/manifest.json`
@@ -851,7 +858,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-9`;
       const stub = getStub('bucket:2026060917');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       const result = await stub.updateRequestFields(requestId, {
         externalJson: { firestoreDocId: 'doc123', gcsPath: 'gs://bucket/path' }
@@ -883,7 +890,7 @@ describe('LoggerDO', () => {
         requestId,
         url: 'https://example.com/article',
         optionsR2Key: `archives/${requestId}/input/options.json`
-      });
+      }, new Date().toISOString());
 
       await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
@@ -917,7 +924,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-11`;
       const stub = getStub('bucket:2026060919');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       // Add 5 events
       for (let i = 0; i < 5; i++) {
@@ -962,7 +969,7 @@ describe('LoggerDO', () => {
       const requestId = `test-${Date.now()}-12`;
       const stub = getStub('bucket:2026060920');
 
-      await stub.initRequest({ requestId, url: 'https://example.com' });
+      await stub.initRequest({ requestId, url: 'https://example.com' }, new Date().toISOString());
 
       for (let i = 0; i < 3; i++) {
         await stub.appendEvent(requestId, {
@@ -989,5 +996,103 @@ describe('LoggerDO', () => {
         expect(result2?.nextCursor).toBeUndefined();
       }
     });
+  });
+});
+
+/**
+ * HTTP-layer dual-read routing tests via the SELF fetcher.
+ *
+ * These tests exercise the service worker's fetch handler (index.ts default
+ * export) rather than the DO RPC methods directly.  Each test populates the
+ * D1 index and/or the relevant DO instances via the DO stub API (same path
+ * as the DO-level tests above) and then issues HTTP requests through SELF.
+ *
+ * INTERNAL_API_KEY is set in .dev.vars and is read by the worker at runtime.
+ */
+describe('Logger HTTP service routing (dual-read)', () => {
+  // The key stored in .dev.vars and read by the worker
+  const API_KEY = 'verify-test-key-local-only';
+
+  function serviceGet(path: string): Promise<Response> {
+    return SELF.fetch(`https://logger.internal${path}`, {
+      headers: { 'X-Internal-API-Key': API_KEY }
+    });
+  }
+
+  function servicePatch(path: string, body: unknown): Promise<Response> {
+    return SELF.fetch(`https://logger.internal${path}`, {
+      method: 'PATCH',
+      headers: {
+        'X-Internal-API-Key': API_KEY,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+  }
+
+  it('GET /request/:id — bucket hit: D1 row resolves bucket key, bucket DO has data, returns view', async () => {
+    const requestId = `svc-bucket-hit-${Date.now()}`;
+    // Pick a fixed creation hour so the bucket key is deterministic
+    const createdAt = '2026-06-08T07:00:00.000Z';
+    const bucketKey = 'bucket:2026060807';
+
+    // Seed the bucket DO with the request
+    const bucketStub = getStub(bucketKey);
+    await bucketStub.initRequest({ requestId, url: 'https://example.com/bucket-hit' }, createdAt);
+    await bucketStub.appendEvent(requestId, infoEvent('request.created', 'created'));
+
+    // Seed the D1 index so the service can derive the bucket key
+    await env.INDEX_DB.prepare(
+      `INSERT OR IGNORE INTO requests_index
+       (request_id, url, domain, created_at, updated_at, stage)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+      .bind(requestId, 'https://example.com/bucket-hit', 'example.com', createdAt, createdAt, 'queued')
+      .run();
+
+    const res = await serviceGet(`/request/${requestId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { url: string; events: unknown[] };
+    expect(body.url).toBe('https://example.com/bucket-hit');
+    expect(body.events).toHaveLength(1);
+  });
+
+  it('GET /request/:id — bucket miss with D1 row: falls back to legacy per-request DO', async () => {
+    const requestId = `svc-bucket-miss-${Date.now()}`;
+    // created_at points to a bucket that holds NO data for this request
+    const createdAt = '2026-06-08T08:00:00.000Z'; // bucket:2026060808 — intentionally left empty
+    // Seed ONLY the legacy per-request DO (instance keyed by requestId)
+    const legacyStub = getStub(requestId);
+    await legacyStub.initRequest({ requestId, url: 'https://example.com/legacy-fallback' }, createdAt);
+    await legacyStub.appendEvent(requestId, infoEvent('request.created', 'legacy created'));
+
+    // Seed D1 so the service looks up the (empty) bucket and falls through to legacy
+    await env.INDEX_DB.prepare(
+      `INSERT OR IGNORE INTO requests_index
+       (request_id, url, domain, created_at, updated_at, stage)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+      .bind(requestId, 'https://example.com/legacy-fallback', 'example.com', createdAt, createdAt, 'queued')
+      .run();
+
+    const res = await serviceGet(`/request/${requestId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { url: string; events: unknown[] };
+    expect(body.url).toBe('https://example.com/legacy-fallback');
+    expect(body.events).toHaveLength(1);
+  });
+
+  it('GET /request/:id — both miss: no D1 row, no DO data → 404', async () => {
+    const requestId = `svc-both-miss-${Date.now()}`;
+    // No D1 row, no DO data — nothing to find
+    const res = await serviceGet(`/request/${requestId}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('PATCH /request/:id — unknown request id → 404', async () => {
+    const requestId = `svc-patch-unknown-${Date.now()}`;
+    // No D1 row, no DO data
+    const res = await servicePatch(`/request/${requestId}`, { manifestR2Key: 'some/key' });
+    expect(res.status).toBe(404);
   });
 });

--- a/warg/workers/logger/src/LoggerDO.test.ts
+++ b/warg/workers/logger/src/LoggerDO.test.ts
@@ -1,4 +1,4 @@
-import { env } from 'cloudflare:test';
+import { env, runInDurableObject } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import type {
   InitRequestPayload,
@@ -8,6 +8,7 @@ import type {
   DerivedSummary,
   RequestFieldsPatch
 } from '@warg/shared';
+import { bucketKeyForTs } from './index.js';
 
 interface LoggerEventWithId {
   id: number;
@@ -21,31 +22,63 @@ interface LoggerEventWithId {
 }
 
 interface LoggerStub {
-  initRequest(payload: InitRequestPayload): Promise<{ created: boolean }>;
-  appendEvent(event: LogEvent): Promise<{ eventId: number }>;
-  upsertArtifact(artifact: ArtifactRecord): Promise<void> | void;
-  updateRequestFields(patch: RequestFieldsPatch): Promise<void>;
-  getRequestView(cursor?: number, limit?: number): Promise<CanonicalRequestView | null> | CanonicalRequestView | null;
+  initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
+  appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
+  upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
+  updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
+  getRequestView(
+    requestId: string,
+    cursor?: number,
+    limit?: number
+  ): Promise<CanonicalRequestView | null> | CanonicalRequestView | null;
   getEventsForStream(
+    requestId: string,
     cursor?: number,
     limit?: number
   ): Promise<{ events: LoggerEventWithId[]; derived: DerivedSummary; artifacts: ArtifactRecord[] } | null> | { events: LoggerEventWithId[]; derived: DerivedSummary; artifacts: ArtifactRecord[] } | null;
-  getEvents(cursor?: number, limit?: number): Promise<{ events: LogEvent[]; nextCursor?: number }> | { events: LogEvent[]; nextCursor?: number };
+  getEvents(
+    requestId: string,
+    cursor?: number,
+    limit?: number
+  ): Promise<{ events: LogEvent[]; nextCursor?: number } | null> | { events: LogEvent[]; nextCursor?: number } | null;
 }
 
 /**
- * Helper to get a fresh DO stub for testing.
+ * Helper to get a DO stub by instance key (bucket key or legacy request id).
  */
-function getStub(requestId: string): LoggerStub {
-  const id = env.LOGGER_DO.idFromName(requestId);
+function getStub(key: string): LoggerStub {
+  const id = env.LOGGER_DO.idFromName(key);
   return env.LOGGER_DO.get(id) as unknown as LoggerStub;
 }
+
+function infoEvent(type: LogEvent['type'], message: string, data?: Record<string, unknown>): LogEvent {
+  return {
+    ts: new Date().toISOString(),
+    source: 'workflow',
+    type,
+    level: 'info',
+    message,
+    ...(data ? { data } : {})
+  };
+}
+
+describe('bucketKeyForTs', () => {
+  it('buckets by UTC hour', () => {
+    expect(bucketKeyForTs('2026-12-09T23:59:59Z')).toBe('bucket:2026120923');
+    expect(bucketKeyForTs('2026-06-10T00:00:00.000Z')).toBe('bucket:2026061000');
+    expect(bucketKeyForTs('2026-06-10T00:59:59.999Z')).toBe('bucket:2026061000');
+  });
+
+  it('normalizes zoned timestamps to UTC', () => {
+    expect(bucketKeyForTs('2026-01-05T07:30:00+01:00')).toBe('bucket:2026010506');
+  });
+});
 
 describe('LoggerDO', () => {
   describe('initRequest', () => {
     it('creates a new request record', async () => {
       const requestId = `test-${Date.now()}-1`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060910');
 
       const result = await stub.initRequest({
         requestId,
@@ -58,7 +91,7 @@ describe('LoggerDO', () => {
 
     it('is idempotent for existing requests', async () => {
       const requestId = `test-${Date.now()}-2`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060910');
 
       const payload: InitRequestPayload = {
         requestId,
@@ -71,12 +104,166 @@ describe('LoggerDO', () => {
       expect(first.created).toBe(true);
       expect(second.created).toBe(false);
     });
+
+    it('stores the service-supplied createdAt', async () => {
+      const requestId = `test-${Date.now()}-2b`;
+      const createdAt = '2026-06-09T14:30:00.000Z';
+      const stub = getStub(bucketKeyForTs(createdAt));
+
+      await stub.initRequest({ requestId, url: 'https://example.com' }, createdAt);
+
+      const view = await stub.getRequestView(requestId);
+      expect(view?.createdAt).toBe(createdAt);
+    });
+  });
+
+  describe('hour-bucket keying (multi-request instance)', () => {
+    it('isolates events, artifacts, and derived state per request', async () => {
+      const stub = getStub('bucket:2026060914');
+      const reqA = `bucket-test-${Date.now()}-a`;
+      const reqB = `bucket-test-${Date.now()}-b`;
+
+      await stub.initRequest({ requestId: reqA, url: 'https://example.com/a' });
+      await stub.initRequest({ requestId: reqB, url: 'https://example.com/b' });
+
+      await stub.appendEvent(reqA, infoEvent('step.started', 'Render A', { step: 'render' }));
+      await stub.appendEvent(reqA, {
+        ts: new Date().toISOString(),
+        source: 'workflow',
+        type: 'artifact.written',
+        level: 'info',
+        message: 'Artifact written: rendered.html',
+        data: {
+          kind: 'rendered.html',
+          r2Key: `archives/${reqA}/raw/rendered.html`,
+          bytes: 100,
+          contentType: 'text/html',
+          sha256: 'sha-a'
+        }
+      });
+      await stub.appendEvent(reqA, infoEvent('request.done', 'Done A'));
+      await stub.appendEvent(reqB, infoEvent('step.started', 'Render B', { step: 'render' }));
+
+      const viewA = await stub.getRequestView(reqA);
+      expect(viewA?.requestId).toBe(reqA);
+      expect(viewA?.events).toHaveLength(3);
+      expect(viewA?.events.some((e) => e.message === 'Render B')).toBe(false);
+      expect(viewA?.artifacts).toHaveLength(1);
+      expect(viewA?.artifacts[0]?.r2Key).toContain(reqA);
+      expect(viewA?.derived.stage).toBe('done');
+      expect(viewA?.derived.terminal).toBe(true);
+
+      const viewB = await stub.getRequestView(reqB);
+      expect(viewB?.events).toHaveLength(1);
+      expect(viewB?.artifacts).toHaveLength(0);
+      expect(viewB?.derived.stage).toBe('rendering');
+      expect(viewB?.derived.terminal).toBe(false);
+
+      const streamB = await stub.getEventsForStream(reqB);
+      expect(streamB?.events).toHaveLength(1);
+      expect(streamB?.events[0]?.message).toBe('Render B');
+
+      const eventsA = await stub.getEvents(reqA);
+      expect(eventsA?.events).toHaveLength(3);
+    });
+
+    it('returns null for requests this bucket does not hold (dual-read contract)', async () => {
+      const stub = getStub('bucket:2026060915');
+
+      expect(await stub.getRequestView('missing-req')).toBeNull();
+      expect(await stub.getEventsForStream('missing-req')).toBeNull();
+      expect(await stub.getEvents('missing-req')).toBeNull();
+      expect((await stub.updateRequestFields('missing-req', { manifestR2Key: 'x' })).updated).toBe(
+        false
+      );
+    });
+  });
+
+  describe('legacy per-request instance migration', () => {
+    it('adopts pre-bucket rows under the single request id and serves filtered reads', async () => {
+      const requestId = `legacy-${Date.now()}`;
+      const id = env.LOGGER_DO.idFromName(requestId);
+      const rawStub = env.LOGGER_DO.get(id);
+
+      // Recreate a pre-bucket instance exactly as the old schema wrote it:
+      // no request_id column on events/artifacts, one request per instance.
+      await runInDurableObject(rawStub, async (_instance, state) => {
+        const sql = state.storage.sql;
+        sql.exec(`
+          CREATE TABLE IF NOT EXISTS requests (
+            request_id TEXT PRIMARY KEY,
+            url TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            options_r2_key TEXT,
+            manifest_r2_key TEXT,
+            external_json TEXT,
+            derived_json TEXT NOT NULL DEFAULT '{}'
+          );
+
+          CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            source TEXT NOT NULL,
+            type TEXT NOT NULL,
+            level TEXT NOT NULL,
+            message TEXT NOT NULL,
+            attempt INTEGER,
+            data_json TEXT
+          );
+
+          CREATE TABLE IF NOT EXISTS artifacts (
+            kind TEXT NOT NULL,
+            r2_key TEXT NOT NULL,
+            content_type TEXT NOT NULL,
+            bytes INTEGER NOT NULL,
+            sha256 TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (kind, r2_key)
+          );
+        `);
+        sql.exec(
+          `INSERT INTO requests (request_id, url, created_at, derived_json) VALUES (?, ?, ?, ?)`,
+          requestId,
+          'https://example.com/legacy',
+          '2026-05-01T10:00:00.000Z',
+          JSON.stringify({ stage: 'done', errorCount: 0, terminal: true })
+        );
+        sql.exec(
+          `INSERT INTO events (ts, source, type, level, message) VALUES (?, 'gateway', 'request.created', 'info', 'created')`,
+          '2026-05-01T10:00:00.000Z'
+        );
+        sql.exec(
+          `INSERT INTO events (ts, source, type, level, message) VALUES (?, 'workflow', 'request.done', 'info', 'done')`,
+          '2026-05-01T10:01:00.000Z'
+        );
+        sql.exec(
+          `INSERT INTO artifacts (kind, r2_key, content_type, bytes, sha256) VALUES ('rendered.html', ?, 'text/html', 10, 'sha-legacy')`,
+          `archives/${requestId}/raw/rendered.html`
+        );
+      });
+
+      // First read triggers ensureSchema → migrateSchema, which adds the
+      // request_id columns and backfills them from the single requests row.
+      const stub = rawStub as unknown as LoggerStub;
+      const view = await stub.getRequestView(requestId);
+
+      expect(view).not.toBeNull();
+      expect(view?.requestId).toBe(requestId);
+      expect(view?.events).toHaveLength(2);
+      expect(view?.events[1]?.type).toBe('request.done');
+      expect(view?.artifacts).toHaveLength(1);
+      expect(view?.artifacts[0]?.sha256).toBe('sha-legacy');
+      expect(view?.derived.terminal).toBe(true);
+
+      const stream = await stub.getEventsForStream(requestId);
+      expect(stream?.events).toHaveLength(2);
+    });
   });
 
   describe('appendEvent', () => {
     it('inserts events and returns event ID', async () => {
       const requestId = `test-${Date.now()}-3`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060911');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
@@ -88,13 +275,13 @@ describe('LoggerDO', () => {
         message: 'Request created'
       };
 
-      const result = await stub.appendEvent(event);
+      const result = await stub.appendEvent(requestId, event);
       expect(result.eventId).toBeGreaterThan(0);
     });
 
     it('increments error count for error-level events', async () => {
       const requestId = `test-${Date.now()}-4`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060911');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
@@ -107,25 +294,25 @@ describe('LoggerDO', () => {
         data: { reason: 'timeout' }
       };
 
-      await stub.appendEvent(errorEvent);
+      await stub.appendEvent(requestId, errorEvent);
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.derived.errorCount).toBe(1);
     });
 
     it('updates stage from event type', async () => {
       const requestId = `test-${Date.now()}-5`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060911');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
       {
-        const view1 = await stub.getRequestView();
+        const view1 = await stub.getRequestView(requestId);
         expect(view1?.derived.stage).toBe('queued');
       }
 
       // step.started with step=render → rendering
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'step.started',
@@ -135,12 +322,12 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view2 = await stub.getRequestView();
+        const view2 = await stub.getRequestView(requestId);
         expect(view2?.derived.stage).toBe('rendering');
       }
 
       // step.started with step=derivatives → deriving
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'step.started',
@@ -150,11 +337,11 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view2b = await stub.getRequestView();
+        const view2b = await stub.getRequestView(requestId);
         expect(view2b?.derived.stage).toBe('deriving');
       }
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'gcs',
         type: 'persist.started',
@@ -163,11 +350,11 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view3 = await stub.getRequestView();
+        const view3 = await stub.getRequestView(requestId);
         expect(view3?.derived.stage).toBe('persisting');
       }
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'request.done',
@@ -176,7 +363,7 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view4 = await stub.getRequestView();
+        const view4 = await stub.getRequestView(requestId);
         expect(view4?.derived.stage).toBe('done');
         expect(view4?.derived.terminal).toBe(true);
       }
@@ -184,11 +371,11 @@ describe('LoggerDO', () => {
 
     it('stores diagnostics fields for errors and durations', async () => {
       const requestId = `test-${Date.now()}-5b`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060912');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'step.completed',
@@ -203,7 +390,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'step.completed',
@@ -212,7 +399,7 @@ describe('LoggerDO', () => {
         data: { step: 'readability', duration_ms: 850 },
       });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'gcs',
         type: 'persist.completed',
@@ -221,7 +408,7 @@ describe('LoggerDO', () => {
         data: { duration_ms: 4000 },
       });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'renderer',
         type: 'step.failed',
@@ -237,7 +424,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'workflow.completed',
@@ -249,7 +436,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.derived.diagnostics?.errorCode).toBe('RENDER_TIMEOUT');
       expect(view?.derived.diagnostics?.errorSource).toBe('renderer');
       expect(view?.derived.diagnostics?.retryable).toBe(true);
@@ -268,11 +455,11 @@ describe('LoggerDO', () => {
 
     it('marks stage as incomplete when workflow completes with degraded monolith output', async () => {
       const requestId = `test-${Date.now()}-5c-incomplete`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060912');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'workflow.completed',
@@ -284,7 +471,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.derived.stage).toBe('incomplete');
       expect(view?.derived.terminal).toBe(true);
       expect(view?.derived.diagnostics?.degraded).toBe(true);
@@ -293,11 +480,11 @@ describe('LoggerDO', () => {
 
     it('treats workflow.failed as terminal fallback and allows retry to reopen stage', async () => {
       const requestId = `test-${Date.now()}-5c`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060912');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'step.started',
@@ -307,12 +494,12 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view1 = await stub.getRequestView();
+        const view1 = await stub.getRequestView(requestId);
         expect(view1?.derived.stage).toBe('deriving');
         expect(view1?.derived.terminal).toBe(false);
       }
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'workflow.failed',
@@ -321,12 +508,12 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view2 = await stub.getRequestView();
+        const view2 = await stub.getRequestView(requestId);
         expect(view2?.derived.stage).toBe('failed');
         expect(view2?.derived.terminal).toBe(true);
       }
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'gateway',
         type: 'request.created',
@@ -335,7 +522,7 @@ describe('LoggerDO', () => {
       });
 
       {
-        const view3 = await stub.getRequestView();
+        const view3 = await stub.getRequestView(requestId);
         expect(view3?.derived.stage).toBe('queued');
         expect(view3?.derived.terminal).toBe(false);
       }
@@ -343,11 +530,11 @@ describe('LoggerDO', () => {
 
     it('treats workflow.completed as done fallback when request.done is missing', async () => {
       const requestId = `test-${Date.now()}-5d`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060913');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'workflow.completed',
@@ -355,18 +542,18 @@ describe('LoggerDO', () => {
         message: 'Workflow completed'
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.derived.stage).toBe('done');
       expect(view?.derived.terminal).toBe(true);
     });
 
     it('materializes artifacts from artifact.written events when metadata is complete', async () => {
       const requestId = `test-${Date.now()}-5e`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060913');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'artifact.written',
@@ -381,7 +568,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(1);
       expect(view?.artifacts[0]?.kind).toBe('rendered.html');
       expect(view?.artifacts[0]?.bytes).toBe(321);
@@ -390,11 +577,11 @@ describe('LoggerDO', () => {
 
     it('ignores artifact.written events with incomplete metadata', async () => {
       const requestId = `test-${Date.now()}-5f`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060913');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'workflow',
         type: 'artifact.written',
@@ -407,7 +594,7 @@ describe('LoggerDO', () => {
         },
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(0);
     });
   });
@@ -415,7 +602,7 @@ describe('LoggerDO', () => {
   describe('upsertArtifact', () => {
     it('inserts a new artifact', async () => {
       const requestId = `test-${Date.now()}-6`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060916');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
@@ -427,9 +614,9 @@ describe('LoggerDO', () => {
         sha256: 'abc123'
       };
 
-      await stub.upsertArtifact(artifact);
+      await stub.upsertArtifact(requestId, artifact);
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(1);
       expect(view?.artifacts[0]?.kind).toBe('rendered.html');
       expect(view?.artifacts[0]?.bytes).toBe(12345);
@@ -437,7 +624,7 @@ describe('LoggerDO', () => {
 
     it('replaces artifact on conflict (same kind + r2_key)', async () => {
       const requestId = `test-${Date.now()}-7`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060916');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
@@ -457,10 +644,10 @@ describe('LoggerDO', () => {
         sha256: 'second'
       };
 
-      await stub.upsertArtifact(artifact1);
-      await stub.upsertArtifact(artifact2);
+      await stub.upsertArtifact(requestId, artifact1);
+      await stub.upsertArtifact(requestId, artifact2);
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(1);
       expect(view?.artifacts[0]?.bytes).toBe(200);
       expect(view?.artifacts[0]?.sha256).toBe('second');
@@ -470,29 +657,31 @@ describe('LoggerDO', () => {
   describe('updateRequestFields', () => {
     it('updates manifest_r2_key', async () => {
       const requestId = `test-${Date.now()}-8`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060917');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.updateRequestFields({
+      const result = await stub.updateRequestFields(requestId, {
         manifestR2Key: `archives/${requestId}/manifest.json`
       });
+      expect(result.updated).toBe(true);
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.manifestR2Key).toBe(`archives/${requestId}/manifest.json`);
     });
 
     it('updates external_json', async () => {
       const requestId = `test-${Date.now()}-9`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060917');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
-      await stub.updateRequestFields({
+      const result = await stub.updateRequestFields(requestId, {
         externalJson: { firestoreDocId: 'doc123', gcsPath: 'gs://bucket/path' }
       });
+      expect(result.updated).toBe(true);
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view?.externalJson).toEqual({
         firestoreDocId: 'doc123',
         gcsPath: 'gs://bucket/path'
@@ -503,15 +692,15 @@ describe('LoggerDO', () => {
   describe('getRequestView', () => {
     it('returns null for non-existent request', async () => {
       const requestId = `test-nonexistent-${Date.now()}`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060918');
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
       expect(view).toBeNull();
     });
 
     it('returns full view with events and artifacts', async () => {
       const requestId = `test-${Date.now()}-10`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060918');
 
       await stub.initRequest({
         requestId,
@@ -519,7 +708,7 @@ describe('LoggerDO', () => {
         optionsR2Key: `archives/${requestId}/input/options.json`
       });
 
-      await stub.appendEvent({
+      await stub.appendEvent(requestId, {
         ts: new Date().toISOString(),
         source: 'gateway',
         type: 'request.created',
@@ -527,7 +716,7 @@ describe('LoggerDO', () => {
         message: 'Request created'
       });
 
-      await stub.upsertArtifact({
+      await stub.upsertArtifact(requestId, {
         kind: 'screenshot.png',
         r2Key: `archives/${requestId}/raw/screenshot.png`,
         contentType: 'image/png',
@@ -535,7 +724,7 @@ describe('LoggerDO', () => {
         sha256: 'screenshotsha'
       });
 
-      const view = await stub.getRequestView();
+      const view = await stub.getRequestView(requestId);
 
       expect(view).not.toBeNull();
       expect(view?.requestId).toBe(requestId);
@@ -549,13 +738,13 @@ describe('LoggerDO', () => {
 
     it('paginates events', async () => {
       const requestId = `test-${Date.now()}-11`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060919');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
       // Add 5 events
       for (let i = 0; i < 5; i++) {
-        await stub.appendEvent({
+        await stub.appendEvent(requestId, {
           ts: new Date().toISOString(),
           source: 'workflow',
           type: 'step.started',
@@ -568,7 +757,7 @@ describe('LoggerDO', () => {
 
       // Get first page (limit 2)
       {
-        const page1 = await stub.getRequestView(undefined, 2);
+        const page1 = await stub.getRequestView(requestId, undefined, 2);
         expect(page1?.events).toHaveLength(2);
         expect(page1?.nextCursor).toBeDefined();
         nextCursor = page1?.nextCursor;
@@ -576,7 +765,7 @@ describe('LoggerDO', () => {
 
       // Get second page
       {
-        const page2 = await stub.getRequestView(nextCursor, 2);
+        const page2 = await stub.getRequestView(requestId, nextCursor, 2);
         expect(page2?.events).toHaveLength(2);
         expect(page2?.nextCursor).toBeDefined();
         nextCursor = page2?.nextCursor;
@@ -584,7 +773,7 @@ describe('LoggerDO', () => {
 
       // Get third page (only 1 remaining)
       {
-        const page3 = await stub.getRequestView(nextCursor, 2);
+        const page3 = await stub.getRequestView(requestId, nextCursor, 2);
         expect(page3?.events).toHaveLength(1);
         expect(page3?.nextCursor).toBeUndefined();
       }
@@ -594,12 +783,12 @@ describe('LoggerDO', () => {
   describe('getEvents', () => {
     it('returns paginated events only', async () => {
       const requestId = `test-${Date.now()}-12`;
-      const stub = getStub(requestId);
+      const stub = getStub('bucket:2026060920');
 
       await stub.initRequest({ requestId, url: 'https://example.com' });
 
       for (let i = 0; i < 3; i++) {
-        await stub.appendEvent({
+        await stub.appendEvent(requestId, {
           ts: new Date().toISOString(),
           source: 'workflow',
           type: 'step.completed',
@@ -611,16 +800,16 @@ describe('LoggerDO', () => {
       let nextCursor: number | undefined;
 
       {
-        const result = await stub.getEvents(undefined, 2);
-        expect(result.events).toHaveLength(2);
-        expect(result.nextCursor).toBeDefined();
-        nextCursor = result.nextCursor;
+        const result = await stub.getEvents(requestId, undefined, 2);
+        expect(result?.events).toHaveLength(2);
+        expect(result?.nextCursor).toBeDefined();
+        nextCursor = result?.nextCursor;
       }
 
       {
-        const result2 = await stub.getEvents(nextCursor, 2);
-        expect(result2.events).toHaveLength(1);
-        expect(result2.nextCursor).toBeUndefined();
+        const result2 = await stub.getEvents(requestId, nextCursor, 2);
+        expect(result2?.events).toHaveLength(1);
+        expect(result2?.nextCursor).toBeUndefined();
       }
     });
   });

--- a/warg/workers/logger/src/LoggerDO.test.ts
+++ b/warg/workers/logger/src/LoggerDO.test.ts
@@ -24,6 +24,7 @@ interface LoggerEventWithId {
 interface LoggerStub {
   initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
   appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
+  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }>;
   upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
   updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
   getRequestView(
@@ -596,6 +597,182 @@ describe('LoggerDO', () => {
 
       const view = await stub.getRequestView(requestId);
       expect(view?.artifacts).toHaveLength(0);
+    });
+  });
+
+  describe('appendEvents', () => {
+    it('returns empty eventIds for an empty batch without touching state', async () => {
+      const requestId = `test-${Date.now()}-be`;
+      const stub = getStub('bucket:2026061010');
+
+      await stub.initRequest({ requestId, url: 'https://example.com' });
+
+      const result = await stub.appendEvents(requestId, []);
+      expect(result.eventIds).toEqual([]);
+
+      const view = await stub.getRequestView(requestId);
+      expect(view?.events).toHaveLength(0);
+      expect(view?.derived.stage).toBe('queued');
+    });
+
+    it('produces the same derived state as sequential appendEvent calls', async () => {
+      const seqId = `test-${Date.now()}-bs`;
+      const batchId = `test-${Date.now()}-bb`;
+      const stub = getStub('bucket:2026061011');
+
+      await stub.initRequest({ requestId: seqId, url: 'https://example.com' });
+      await stub.initRequest({ requestId: batchId, url: 'https://example.com' });
+
+      // Same event objects replayed both ways, so ts values match exactly
+      const events: LogEvent[] = [
+        infoEvent('step.started', 'Renderer step started', { step: 'render' }),
+        {
+          ts: new Date().toISOString(),
+          source: 'renderer',
+          type: 'step.failed',
+          level: 'error',
+          message: 'Rendering failed once',
+          data: { reason: 'timeout' }
+        },
+        infoEvent('persist.started', 'Persisting to GCS')
+      ];
+
+      for (const event of events) {
+        await stub.appendEvent(seqId, event);
+      }
+      const result = await stub.appendEvents(batchId, events);
+
+      expect(result.eventIds).toHaveLength(events.length);
+
+      const seqView = await stub.getRequestView(seqId);
+      const batchView = await stub.getRequestView(batchId);
+      expect(batchView?.derived).toEqual(seqView?.derived);
+      expect(batchView?.derived.stage).toBe('persisting');
+      expect(batchView?.derived.errorCount).toBe(1);
+      expect(batchView?.events).toHaveLength(events.length);
+    });
+
+    it('sets terminal state when the batch ends with request.done', async () => {
+      const requestId = `test-${Date.now()}-bt`;
+      const stub = getStub('bucket:2026061012');
+
+      await stub.initRequest({ requestId, url: 'https://example.com' });
+
+      await stub.appendEvents(requestId, [
+        infoEvent('step.started', 'Renderer step started', { step: 'render' }),
+        infoEvent('request.done', 'Request completed')
+      ]);
+
+      const view = await stub.getRequestView(requestId);
+      expect(view?.derived.stage).toBe('done');
+      expect(view?.derived.terminal).toBe(true);
+    });
+
+    it('keeps terminal state when a non-stage event follows request.done in the batch', async () => {
+      const requestId = `test-${Date.now()}-bk`;
+      const stub = getStub('bucket:2026061013');
+
+      await stub.initRequest({ requestId, url: 'https://example.com' });
+
+      // step.completed maps to no stage, so the sequential state machine
+      // leaves the terminal 'done' untouched — the batch replay must too
+      await stub.appendEvents(requestId, [
+        infoEvent('request.done', 'Request completed'),
+        infoEvent('step.completed', 'Late persist bookkeeping', { step: 'persist', duration_ms: 12 })
+      ]);
+
+      const view = await stub.getRequestView(requestId);
+      expect(view?.derived.stage).toBe('done');
+      expect(view?.derived.terminal).toBe(true);
+    });
+
+    it('materializes artifacts from artifact.written events in the batch', async () => {
+      const requestId = `test-${Date.now()}-ba`;
+      const stub = getStub('bucket:2026061014');
+
+      await stub.initRequest({ requestId, url: 'https://example.com' });
+
+      const result = await stub.appendEvents(requestId, [
+        infoEvent('artifact.written', 'Artifact written: rendered.html', {
+          kind: 'rendered.html',
+          r2Key: `archives/${requestId}/raw/rendered.html`,
+          contentType: 'text/html',
+          bytes: 1024,
+          sha256: 'abc123'
+        }),
+        infoEvent('artifact.written', 'Artifact written: screenshot.png', {
+          kind: 'screenshot.png',
+          r2Key: `archives/${requestId}/raw/screenshot.png`,
+          contentType: 'image/png',
+          bytes: 2048,
+          sha256: 'def456'
+        })
+      ]);
+
+      expect(result.eventIds).toHaveLength(2);
+
+      const view = await stub.getRequestView(requestId);
+      expect(view?.artifacts).toHaveLength(2);
+      const kinds = view?.artifacts.map((artifact) => artifact.kind).sort();
+      expect(kinds).toEqual(['rendered.html', 'screenshot.png']);
+    });
+
+    it('matches sequential appendEvent on a complex mixed sequence', async () => {
+      const seqId = `test-${Date.now()}-bcs`;
+      const batchId = `test-${Date.now()}-bcb`;
+      const stub = getStub('bucket:2026061015');
+
+      await stub.initRequest({ requestId: seqId, url: 'https://example.com' });
+      await stub.initRequest({ requestId: batchId, url: 'https://example.com' });
+
+      const events: LogEvent[] = [
+        infoEvent('workflow.started', 'Workflow started'),
+        infoEvent('step.started', 'Renderer step started', { step: 'render' }),
+        infoEvent('step.completed', 'Render done', {
+          step: 'render',
+          duration_ms: 1234,
+          fallbackUsed: false
+        }),
+        infoEvent('artifact.written', 'Artifact written: rendered.html', {
+          kind: 'rendered.html',
+          r2Key: 'archives/x/raw/rendered.html',
+          contentType: 'text/html',
+          bytes: 512,
+          sha256: 'aaa'
+        }),
+        {
+          ts: new Date().toISOString(),
+          source: 'monolith',
+          type: 'step.failed',
+          level: 'error',
+          message: 'Monolith failed',
+          attempt: 2,
+          data: { errorCode: 'MONOLITH_SERVICE_ERROR', error: 'boom', retryable: true }
+        },
+        infoEvent('persist.completed', 'Persist completed', { duration_ms: 321 }),
+        infoEvent('request.done', 'Request completed', {
+          degraded: true,
+          degradedSteps: ['monolith']
+        })
+      ];
+
+      for (const event of events) {
+        await stub.appendEvent(seqId, event);
+      }
+      await stub.appendEvents(batchId, events);
+
+      const seqView = await stub.getRequestView(seqId);
+      const batchView = await stub.getRequestView(batchId);
+
+      expect(batchView?.derived).toEqual(seqView?.derived);
+      // degraded monolith → the incomplete override fires in both replays
+      expect(batchView?.derived.stage).toBe('incomplete');
+      expect(batchView?.derived.terminal).toBe(true);
+      expect(batchView?.derived.diagnostics?.renderMs).toBe(1234);
+      expect(batchView?.derived.diagnostics?.persistMs).toBe(321);
+      expect(batchView?.derived.diagnostics?.retryCount).toBe(2);
+      expect(batchView?.events).toHaveLength(events.length);
+      expect(batchView?.artifacts).toHaveLength(1);
     });
   });
 

--- a/warg/workers/logger/src/LoggerDO.test.ts
+++ b/warg/workers/logger/src/LoggerDO.test.ts
@@ -8,7 +8,7 @@ import type {
   DerivedSummary,
   RequestFieldsPatch
 } from '@warg/shared';
-import { bucketKeyForTs } from './index.js';
+import { bucketKeyForTs } from './bucket-key.js';
 
 interface LoggerEventWithId {
   id: number;

--- a/warg/workers/logger/src/LoggerDO.ts
+++ b/warg/workers/logger/src/LoggerDO.ts
@@ -501,6 +501,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
         // Reset closure state here so a callback retry starts clean (M9a).
         eventIds = [];
         finalDerived = undefined;
+        derivedUpdated = false;
 
         const requestRow = this.sql
           .exec<Pick<RequestRow, 'request_id' | 'derived_json'>>(

--- a/warg/workers/logger/src/LoggerDO.ts
+++ b/warg/workers/logger/src/LoggerDO.ts
@@ -456,6 +456,138 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
   }
 
   /**
+   * Append a batch of events to the request trace atomically.
+   * Replays the same per-event state machine as appendEvent in order, so the
+   * final derived summary is identical to N sequential appendEvent calls.
+   * All SQLite writes happen in one transaction (all-or-nothing); the D1
+   * index is updated once with the final derived state instead of per event.
+   */
+  async appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }> {
+    this.ensureSchema();
+
+    if (events.length === 0) {
+      return { eventIds: [] };
+    }
+
+    const eventIds: number[] = [];
+    let finalDerived: DerivedSummary | undefined;
+
+    this.ctx.storage.transactionSync(() => {
+      const requestRows = this.sql
+        .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
+        .toArray();
+      const requestRow = requestRows[0];
+      // Same contract as appendEvent: events are stored even when this
+      // instance holds no request row; only the derived update is skipped.
+      const derived: DerivedSummary | undefined = requestRow
+        ? JSON.parse(requestRow.derived_json)
+        : undefined;
+
+      for (const event of events) {
+        this.sql.exec(
+          `INSERT INTO events (request_id, ts, source, type, level, message, attempt, data_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          requestId,
+          event.ts,
+          event.source,
+          event.type,
+          event.level,
+          event.message,
+          event.attempt ?? null,
+          event.data ? JSON.stringify(event.data) : null
+        );
+        const lastRow = this.sql.exec<{ id: number }>('SELECT last_insert_rowid() as id').one();
+        eventIds.push(lastRow?.id ?? 0);
+
+        const artifact = artifactFromEvent(event);
+        if (artifact) {
+          this.upsertArtifact(requestId, artifact);
+        }
+
+        if (!derived) continue;
+
+        const newStage = deriveStage(event.type, event.data);
+        if (newStage) {
+          derived.stage = newStage;
+          derived.terminal =
+            newStage === 'done' ||
+            newStage === 'failed' ||
+            newStage === 'incomplete';
+        }
+
+        if (event.level === 'error') {
+          derived.errorCount++;
+        }
+
+        derived.lastEventTs = event.ts;
+        derived.diagnostics = updateDiagnostics(derived.diagnostics, event);
+
+        if (
+          (event.type === 'request.done' || event.type === 'workflow.completed') &&
+          shouldMarkIncompleteFromDiagnostics(derived.diagnostics)
+        ) {
+          derived.stage = 'incomplete';
+          derived.terminal = true;
+        }
+      }
+
+      if (requestRow && derived) {
+        this.sql.exec(
+          'UPDATE requests SET derived_json = ? WHERE request_id = ?',
+          JSON.stringify(derived),
+          requestRow.request_id
+        );
+        finalDerived = derived;
+      }
+    });
+
+    // Update D1 index once with the final state (best-effort)
+    if (finalDerived) {
+      const lastEvent = events[events.length - 1]!;
+      try {
+        await this.env.INDEX_DB.prepare(
+          `UPDATE requests_index
+           SET updated_at = ?, last_event_ts = ?, stage = ?,
+               terminal_state = ?, error_count = ?,
+               last_error_code = ?, last_error_message = ?, last_error_source = ?,
+               retry_count = ?, render_ms = ?, derive_ms = ?, persist_ms = ?,
+               last_trace_id = ?, render_provider = ?, render_fallback_used = ?,
+               render_fallback_reason = ?, degraded = ?, degraded_steps = ?
+           WHERE request_id = ?`
+        )
+          .bind(
+            new Date().toISOString(),
+            lastEvent.ts,
+            finalDerived.stage,
+            finalDerived.terminal ? 1 : 0,
+            finalDerived.errorCount,
+            finalDerived.diagnostics?.errorCode ?? null,
+            finalDerived.diagnostics?.errorMessage ?? null,
+            finalDerived.diagnostics?.errorSource ?? null,
+            finalDerived.diagnostics?.retryCount ?? 0,
+            finalDerived.diagnostics?.renderMs ?? null,
+            finalDerived.diagnostics?.deriveMs ?? null,
+            finalDerived.diagnostics?.persistMs ?? null,
+            finalDerived.diagnostics?.lastTraceId ?? null,
+            finalDerived.diagnostics?.renderProvider ?? null,
+            finalDerived.diagnostics?.renderFallbackUsed === true ? 1 : 0,
+            finalDerived.diagnostics?.renderFallbackReason ?? null,
+            finalDerived.diagnostics?.degraded === true ? 1 : 0,
+            finalDerived.diagnostics?.degradedSteps?.length
+              ? JSON.stringify(finalDerived.diagnostics.degradedSteps)
+              : null,
+            requestId
+          )
+          .run();
+      } catch (err) {
+        console.error(`D1 index batch update failed for ${requestId}:`, err instanceof Error ? err.message : err);
+      }
+    }
+
+    return { eventIds };
+  }
+
+  /**
    * Upsert an artifact record.
    * Multiple artifacts of the same kind with different r2_key are allowed.
    */

--- a/warg/workers/logger/src/LoggerDO.ts
+++ b/warg/workers/logger/src/LoggerDO.ts
@@ -10,7 +10,7 @@ import type {
   RequestStage,
   TerminalState
 } from '@warg/shared';
-import { initSchema } from './schema.js';
+import { initSchema, migrateSchema } from './schema.js';
 
 interface LoggerDoEnv {
   INDEX_DB: D1Database;
@@ -28,6 +28,7 @@ interface RequestRow extends Record<string, SqlStorageValue> {
 
 interface EventRow extends Record<string, SqlStorageValue> {
   id: number;
+  request_id: string;
   ts: string;
   source: string;
   type: string;
@@ -38,6 +39,7 @@ interface EventRow extends Record<string, SqlStorageValue> {
 }
 
 interface ArtifactRow extends Record<string, SqlStorageValue> {
+  request_id: string;
   kind: string;
   r2_key: string;
   content_type: string;
@@ -271,6 +273,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
   private ensureSchema(): void {
     if (!this.initialized) {
       initSchema(this.sql);
+      migrateSchema(this.sql);
       this.initialized = true;
     }
   }
@@ -278,8 +281,15 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
   /**
    * Initialize a new request record.
    * Idempotent: if request already exists, returns existing data.
+   *
+   * `createdAt` is supplied by the service so it always falls inside this
+   * bucket's hour — reads derive the bucket key from the D1-indexed
+   * created_at, so the two must never straddle an hour boundary.
    */
-  async initRequest(payload: InitRequestPayload): Promise<{ created: boolean }> {
+  async initRequest(
+    payload: InitRequestPayload,
+    createdAt: string = new Date().toISOString()
+  ): Promise<{ created: boolean }> {
     this.ensureSchema();
 
     const existing = this.sql
@@ -290,7 +300,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
       return { created: false };
     }
 
-    const now = new Date().toISOString();
+    const now = createdAt;
     const initialDerived: DerivedSummary = {
       stage: 'queued',
       errorCount: 0,
@@ -335,13 +345,14 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
    * Append an event to the request trace.
    * Updates derived summary.
    */
-  async appendEvent(event: LogEvent): Promise<{ eventId: number }> {
+  async appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }> {
     this.ensureSchema();
 
     // Insert event
     this.sql.exec(
-      `INSERT INTO events (ts, source, type, level, message, attempt, data_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO events (request_id, ts, source, type, level, message, attempt, data_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      requestId,
       event.ts,
       event.source,
       event.type,
@@ -357,11 +368,13 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
 
     const artifact = artifactFromEvent(event);
     if (artifact) {
-      this.upsertArtifact(artifact);
+      this.upsertArtifact(requestId, artifact);
     }
 
     // Update derived summary
-    const requestRows = this.sql.exec<RequestRow>('SELECT * FROM requests LIMIT 1').toArray();
+    const requestRows = this.sql
+      .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
+      .toArray();
     const requestRow = requestRows[0];
     if (requestRow) {
       const derived: DerivedSummary = JSON.parse(requestRow.derived_json);
@@ -446,12 +459,13 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
    * Upsert an artifact record.
    * Multiple artifacts of the same kind with different r2_key are allowed.
    */
-  upsertArtifact(artifact: ArtifactRecord): void {
+  upsertArtifact(requestId: string, artifact: ArtifactRecord): void {
     this.ensureSchema();
 
     this.sql.exec(
-      `INSERT OR REPLACE INTO artifacts (kind, r2_key, content_type, bytes, sha256)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO artifacts (request_id, kind, r2_key, content_type, bytes, sha256)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      requestId,
       artifact.kind,
       artifact.r2Key,
       artifact.contentType,
@@ -462,14 +476,21 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
 
   /**
    * Update request fields (manifest_r2_key, external_json).
+   * Returns `{ updated: false }` when this instance holds no row for the
+   * request, so the service can fall back to the legacy per-request DO.
    */
-  async updateRequestFields(patch: RequestFieldsPatch): Promise<void> {
+  async updateRequestFields(
+    requestId: string,
+    patch: RequestFieldsPatch
+  ): Promise<{ updated: boolean }> {
     this.ensureSchema();
 
-    const requestRows = this.sql.exec<RequestRow>('SELECT * FROM requests LIMIT 1').toArray();
+    const requestRows = this.sql
+      .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
+      .toArray();
     const requestRow = requestRows[0];
     if (!requestRow) {
-      throw new Error('Request not found');
+      return { updated: false };
     }
 
     const updates: string[] = [];
@@ -505,15 +526,19 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
         }
       }
     }
+
+    return { updated: true };
   }
 
   /**
-   * Get the full canonical view of the request.
+   * Get the full canonical view of a request.
    */
-  getRequestView(cursor?: number, limit = 100): CanonicalRequestView | null {
+  getRequestView(requestId: string, cursor?: number, limit = 100): CanonicalRequestView | null {
     this.ensureSchema();
 
-    const requestRows = this.sql.exec<RequestRow>('SELECT * FROM requests LIMIT 1').toArray();
+    const requestRows = this.sql
+      .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
+      .toArray();
     if (requestRows.length === 0) {
       return null;
     }
@@ -521,18 +546,20 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
 
     // Get events with pagination
     const eventQuery = cursor !== undefined
-      ? 'SELECT * FROM events WHERE id > ? ORDER BY id ASC LIMIT ?'
-      : 'SELECT * FROM events ORDER BY id ASC LIMIT ?';
+      ? 'SELECT * FROM events WHERE request_id = ? AND id > ? ORDER BY id ASC LIMIT ?'
+      : 'SELECT * FROM events WHERE request_id = ? ORDER BY id ASC LIMIT ?';
 
-    const eventArgs = cursor !== undefined ? [cursor, limit + 1] : [limit + 1];
+    const eventArgs = cursor !== undefined ? [requestId, cursor, limit + 1] : [requestId, limit + 1];
     const eventRows = this.sql.exec<EventRow>(eventQuery, ...eventArgs).toArray();
 
     const hasMore = eventRows.length > limit;
     const events = eventRows.slice(0, limit);
     const nextCursor = hasMore && events.length > 0 ? events[events.length - 1]!.id : undefined;
 
-    // Get all artifacts
-    const artifactRows = this.sql.exec<ArtifactRow>('SELECT * FROM artifacts').toArray();
+    // Get the request's artifacts
+    const artifactRows = this.sql
+      .exec<ArtifactRow>('SELECT * FROM artifacts WHERE request_id = ?', requestId)
+      .toArray();
 
     const derived: DerivedSummary = JSON.parse(requestRow.derived_json);
     const externalJson = requestRow.external_json
@@ -573,7 +600,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
    * Get events with their auto-increment IDs, plus derived state and artifacts.
    * Used by the SSE stream handler — IDs become SSE `id:` fields for reconnection.
    */
-  getEventsForStream(cursor?: number, limit = 100): {
+  getEventsForStream(requestId: string, cursor?: number, limit = 100): {
     events: Array<{
       id: number;
       ts: string;
@@ -589,17 +616,21 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
   } | null {
     this.ensureSchema();
 
-    const requestRows = this.sql.exec<RequestRow>('SELECT * FROM requests LIMIT 1').toArray();
+    const requestRows = this.sql
+      .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
+      .toArray();
     if (requestRows.length === 0) return null;
     const requestRow = requestRows[0]!;
 
     const eventQuery = cursor !== undefined
-      ? 'SELECT * FROM events WHERE id > ? ORDER BY id ASC LIMIT ?'
-      : 'SELECT * FROM events ORDER BY id ASC LIMIT ?';
-    const eventArgs = cursor !== undefined ? [cursor, limit] : [limit];
+      ? 'SELECT * FROM events WHERE request_id = ? AND id > ? ORDER BY id ASC LIMIT ?'
+      : 'SELECT * FROM events WHERE request_id = ? ORDER BY id ASC LIMIT ?';
+    const eventArgs = cursor !== undefined ? [requestId, cursor, limit] : [requestId, limit];
     const eventRows = this.sql.exec<EventRow>(eventQuery, ...eventArgs).toArray();
 
-    const artifactRows = this.sql.exec<ArtifactRow>('SELECT * FROM artifacts').toArray();
+    const artifactRows = this.sql
+      .exec<ArtifactRow>('SELECT * FROM artifacts WHERE request_id = ?', requestId)
+      .toArray();
     const derived: DerivedSummary = JSON.parse(requestRow.derived_json);
 
     return {
@@ -626,15 +657,26 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
 
   /**
    * Get paginated events only.
+   * Returns null when this instance holds no row for the request, so the
+   * service can fall back to the legacy per-request DO.
    */
-  getEvents(cursor?: number, limit = 100): { events: LogEvent[]; nextCursor?: number } {
+  getEvents(
+    requestId: string,
+    cursor?: number,
+    limit = 100
+  ): { events: LogEvent[]; nextCursor?: number } | null {
     this.ensureSchema();
 
-    const eventQuery = cursor !== undefined
-      ? 'SELECT * FROM events WHERE id > ? ORDER BY id ASC LIMIT ?'
-      : 'SELECT * FROM events ORDER BY id ASC LIMIT ?';
+    const requestRows = this.sql
+      .exec<RequestRow>('SELECT request_id FROM requests WHERE request_id = ? LIMIT 1', requestId)
+      .toArray();
+    if (requestRows.length === 0) return null;
 
-    const eventArgs = cursor !== undefined ? [cursor, limit + 1] : [limit + 1];
+    const eventQuery = cursor !== undefined
+      ? 'SELECT * FROM events WHERE request_id = ? AND id > ? ORDER BY id ASC LIMIT ?'
+      : 'SELECT * FROM events WHERE request_id = ? ORDER BY id ASC LIMIT ?';
+
+    const eventArgs = cursor !== undefined ? [requestId, cursor, limit + 1] : [requestId, limit + 1];
     const eventRows = this.sql.exec<EventRow>(eventQuery, ...eventArgs).toArray();
 
     const hasMore = eventRows.length > limit;

--- a/warg/workers/logger/src/LoggerDO.ts
+++ b/warg/workers/logger/src/LoggerDO.ts
@@ -11,6 +11,7 @@ import type {
   TerminalState
 } from '@warg/shared';
 import { initSchema, migrateSchema } from './schema.js';
+import { asNumber, asString, asBoolean, asRecord } from './value-helpers.js';
 
 interface LoggerDoEnv {
   INDEX_DB: D1Database;
@@ -73,25 +74,6 @@ function deriveStage(
   if (eventType === 'workflow.started') return 'queued';
   if (eventType === 'request.created') return 'queued';
   return undefined;
-}
-
-function asNumber(value: unknown): number | undefined {
-  if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
-  return value;
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function asStringArray(value: unknown): string[] | undefined {
@@ -261,6 +243,38 @@ function extractDomain(url: string): string {
   }
 }
 
+/**
+ * Apply a single event to a mutable DerivedSummary in-place.
+ * Encapsulates the stage machine, terminal flags, errorCount, lastEventTs,
+ * diagnostics update, and the degraded-monolith incomplete override.
+ * Pure with respect to storage — no SQL side-effects.
+ */
+function applyEventToDerived(derived: DerivedSummary, event: LogEvent): void {
+  const newStage = deriveStage(event.type, event.data);
+  if (newStage) {
+    derived.stage = newStage;
+    derived.terminal =
+      newStage === 'done' ||
+      newStage === 'failed' ||
+      newStage === 'incomplete';
+  }
+
+  if (event.level === 'error') {
+    derived.errorCount++;
+  }
+
+  derived.lastEventTs = event.ts;
+  derived.diagnostics = updateDiagnostics(derived.diagnostics, event);
+
+  if (
+    (event.type === 'request.done' || event.type === 'workflow.completed') &&
+    shouldMarkIncompleteFromDiagnostics(derived.diagnostics)
+  ) {
+    derived.stage = 'incomplete';
+    derived.terminal = true;
+  }
+}
+
 export class LoggerDO extends DurableObject<LoggerDoEnv> {
   private sql: SqlStorage;
   private initialized = false;
@@ -270,11 +284,68 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
     this.sql = ctx.storage.sql;
   }
 
+  /**
+   * Initialise the SQLite schema on first use.
+   * Relies on the DO single-threaded execution model (one request at a time
+   * per instance) — no locking is needed; a concurrent "fix" adding a mutex
+   * here would be unnecessary.
+   */
   private ensureSchema(): void {
     if (!this.initialized) {
       initSchema(this.sql);
       migrateSchema(this.sql);
       this.initialized = true;
+    }
+  }
+
+  /**
+   * Update the D1 requests_index row for a request (best-effort).
+   * @param requestId   - The request to update.
+   * @param lastEventTs - The ts of the event that drove the derived change.
+   * @param derived     - Final derived summary to write.
+   */
+  private async updateD1Index(
+    requestId: string,
+    lastEventTs: string,
+    derived: DerivedSummary
+  ): Promise<void> {
+    try {
+      await this.env.INDEX_DB.prepare(
+        `UPDATE requests_index
+         SET updated_at = ?, last_event_ts = ?, stage = ?,
+             terminal_state = ?, error_count = ?,
+             last_error_code = ?, last_error_message = ?, last_error_source = ?,
+             retry_count = ?, render_ms = ?, derive_ms = ?, persist_ms = ?,
+             last_trace_id = ?, render_provider = ?, render_fallback_used = ?,
+             render_fallback_reason = ?, degraded = ?, degraded_steps = ?
+         WHERE request_id = ?`
+      )
+        .bind(
+          new Date().toISOString(),
+          lastEventTs,
+          derived.stage,
+          derived.terminal ? 1 : 0,
+          derived.errorCount,
+          derived.diagnostics?.errorCode ?? null,
+          derived.diagnostics?.errorMessage ?? null,
+          derived.diagnostics?.errorSource ?? null,
+          derived.diagnostics?.retryCount ?? 0,
+          derived.diagnostics?.renderMs ?? null,
+          derived.diagnostics?.deriveMs ?? null,
+          derived.diagnostics?.persistMs ?? null,
+          derived.diagnostics?.lastTraceId ?? null,
+          derived.diagnostics?.renderProvider ?? null,
+          derived.diagnostics?.renderFallbackUsed === true ? 1 : 0,
+          derived.diagnostics?.renderFallbackReason ?? null,
+          derived.diagnostics?.degraded === true ? 1 : 0,
+          derived.diagnostics?.degradedSteps?.length
+            ? JSON.stringify(derived.diagnostics.degradedSteps)
+            : null,
+          requestId
+        )
+        .run();
+    } catch (err) {
+      console.error(`D1 index update failed for ${requestId}:`, err instanceof Error ? err.message : err);
     }
   }
 
@@ -288,7 +359,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
    */
   async initRequest(
     payload: InitRequestPayload,
-    createdAt: string = new Date().toISOString()
+    createdAt: string
   ): Promise<{ created: boolean }> {
     this.ensureSchema();
 
@@ -348,10 +419,11 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
   async appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }> {
     this.ensureSchema();
 
-    // Insert event
-    this.sql.exec(
+    // Insert event and retrieve its auto-increment id in one statement
+    const insertRow = this.sql.exec<{ id: number }>(
       `INSERT INTO events (request_id, ts, source, type, level, message, attempt, data_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       RETURNING id`,
       requestId,
       event.ts,
       event.source,
@@ -360,50 +432,25 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
       event.message,
       event.attempt ?? null,
       event.data ? JSON.stringify(event.data) : null
-    );
-
-    // Get the inserted event ID
-    const lastRow = this.sql.exec<{ id: number }>('SELECT last_insert_rowid() as id').one();
-    const eventId = lastRow?.id ?? 0;
+    ).one();
+    const eventId = insertRow?.id ?? 0;
 
     const artifact = artifactFromEvent(event);
     if (artifact) {
       this.upsertArtifact(requestId, artifact);
     }
 
-    // Update derived summary
-    const requestRows = this.sql
-      .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
-      .toArray();
-    const requestRow = requestRows[0];
+    // Update derived summary (only request_id + derived_json needed here)
+    const requestRow = this.sql
+      .exec<Pick<RequestRow, 'request_id' | 'derived_json'>>(
+        'SELECT request_id, derived_json FROM requests WHERE request_id = ? LIMIT 1',
+        requestId
+      )
+      .one();
     if (requestRow) {
       const derived: DerivedSummary = JSON.parse(requestRow.derived_json);
 
-      // Update stage if event implies a new stage
-      const newStage = deriveStage(event.type, event.data);
-      if (newStage) {
-        derived.stage = newStage;
-        derived.terminal =
-          newStage === 'done' ||
-          newStage === 'failed' ||
-          newStage === 'incomplete';
-      }
-
-      // Increment error count for error-level events
-      if (event.level === 'error') {
-        derived.errorCount++;
-      }
-
-      derived.lastEventTs = event.ts;
-      derived.diagnostics = updateDiagnostics(derived.diagnostics, event);
-
-      if (
-        (event.type === 'request.done' || event.type === 'workflow.completed') &&
-        shouldMarkIncompleteFromDiagnostics(derived.diagnostics)
-      ) {
-        derived.stage = 'incomplete';
-        derived.terminal = true;
-      }
+      applyEventToDerived(derived, event);
 
       this.sql.exec(
         'UPDATE requests SET derived_json = ? WHERE request_id = ?',
@@ -411,45 +458,7 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
         requestRow.request_id
       );
 
-      // Update D1 index (best-effort)
-      try {
-        await this.env.INDEX_DB.prepare(
-          `UPDATE requests_index
-           SET updated_at = ?, last_event_ts = ?, stage = ?,
-               terminal_state = ?, error_count = ?,
-               last_error_code = ?, last_error_message = ?, last_error_source = ?,
-               retry_count = ?, render_ms = ?, derive_ms = ?, persist_ms = ?,
-               last_trace_id = ?, render_provider = ?, render_fallback_used = ?,
-               render_fallback_reason = ?, degraded = ?, degraded_steps = ?
-           WHERE request_id = ?`
-        )
-          .bind(
-            new Date().toISOString(),
-            event.ts,
-            derived.stage,
-            derived.terminal ? 1 : 0,
-            derived.errorCount,
-            derived.diagnostics?.errorCode ?? null,
-            derived.diagnostics?.errorMessage ?? null,
-            derived.diagnostics?.errorSource ?? null,
-            derived.diagnostics?.retryCount ?? 0,
-            derived.diagnostics?.renderMs ?? null,
-            derived.diagnostics?.deriveMs ?? null,
-            derived.diagnostics?.persistMs ?? null,
-            derived.diagnostics?.lastTraceId ?? null,
-            derived.diagnostics?.renderProvider ?? null,
-            derived.diagnostics?.renderFallbackUsed === true ? 1 : 0,
-            derived.diagnostics?.renderFallbackReason ?? null,
-            derived.diagnostics?.degraded === true ? 1 : 0,
-            derived.diagnostics?.degradedSteps?.length
-              ? JSON.stringify(derived.diagnostics.degradedSteps)
-              : null,
-            requestRow.request_id
-          )
-          .run();
-      } catch (err) {
-        console.error(`D1 index update failed for ${requestRow.request_id}:`, err instanceof Error ? err.message : err);
-      }
+      await this.updateD1Index(requestRow.request_id, event.ts, derived);
     }
 
     return { eventId };
@@ -457,134 +466,108 @@ export class LoggerDO extends DurableObject<LoggerDoEnv> {
 
   /**
    * Append a batch of events to the request trace atomically.
+   *
    * Replays the same per-event state machine as appendEvent in order, so the
    * final derived summary is identical to N sequential appendEvent calls.
    * All SQLite writes happen in one transaction (all-or-nothing); the D1
    * index is updated once with the final derived state instead of per event.
+   *
+   * ASSUMPTION: callers supply events in chronological order. The last
+   * event's `ts` becomes D1's `last_event_ts`.
+   *
+   * @returns `eventIds` — the inserted row ids in order.
+   * @returns `derivedUpdated` — true when a request row existed and
+   *   derived_json was updated. False means no request row was found (routing
+   *   anomaly): events are still stored but derived state is unchanged.
    */
-  async appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }> {
+  async appendEvents(
+    requestId: string,
+    events: LogEvent[]
+  ): Promise<{ eventIds: number[]; derivedUpdated: boolean }> {
     this.ensureSchema();
 
     if (events.length === 0) {
-      return { eventIds: [] };
+      return { eventIds: [], derivedUpdated: false };
     }
 
-    const eventIds: number[] = [];
+    // These are reset at the top of the transactionSync callback so a runtime
+    // retry of the callback cannot accumulate duplicates (M9a).
+    let eventIds: number[] = [];
     let finalDerived: DerivedSummary | undefined;
+    let derivedUpdated = false;
 
-    this.ctx.storage.transactionSync(() => {
-      const requestRows = this.sql
-        .exec<RequestRow>('SELECT * FROM requests WHERE request_id = ? LIMIT 1', requestId)
-        .toArray();
-      const requestRow = requestRows[0];
-      // Same contract as appendEvent: events are stored even when this
-      // instance holds no request row; only the derived update is skipped.
-      const derived: DerivedSummary | undefined = requestRow
-        ? JSON.parse(requestRow.derived_json)
-        : undefined;
+    try {
+      this.ctx.storage.transactionSync(() => {
+        // Reset closure state here so a callback retry starts clean (M9a).
+        eventIds = [];
+        finalDerived = undefined;
 
-      for (const event of events) {
-        this.sql.exec(
-          `INSERT INTO events (request_id, ts, source, type, level, message, attempt, data_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-          requestId,
-          event.ts,
-          event.source,
-          event.type,
-          event.level,
-          event.message,
-          event.attempt ?? null,
-          event.data ? JSON.stringify(event.data) : null
-        );
-        const lastRow = this.sql.exec<{ id: number }>('SELECT last_insert_rowid() as id').one();
-        eventIds.push(lastRow?.id ?? 0);
-
-        const artifact = artifactFromEvent(event);
-        if (artifact) {
-          this.upsertArtifact(requestId, artifact);
-        }
-
-        if (!derived) continue;
-
-        const newStage = deriveStage(event.type, event.data);
-        if (newStage) {
-          derived.stage = newStage;
-          derived.terminal =
-            newStage === 'done' ||
-            newStage === 'failed' ||
-            newStage === 'incomplete';
-        }
-
-        if (event.level === 'error') {
-          derived.errorCount++;
-        }
-
-        derived.lastEventTs = event.ts;
-        derived.diagnostics = updateDiagnostics(derived.diagnostics, event);
-
-        if (
-          (event.type === 'request.done' || event.type === 'workflow.completed') &&
-          shouldMarkIncompleteFromDiagnostics(derived.diagnostics)
-        ) {
-          derived.stage = 'incomplete';
-          derived.terminal = true;
-        }
-      }
-
-      if (requestRow && derived) {
-        this.sql.exec(
-          'UPDATE requests SET derived_json = ? WHERE request_id = ?',
-          JSON.stringify(derived),
-          requestRow.request_id
-        );
-        finalDerived = derived;
-      }
-    });
-
-    // Update D1 index once with the final state (best-effort)
-    if (finalDerived) {
-      const lastEvent = events[events.length - 1]!;
-      try {
-        await this.env.INDEX_DB.prepare(
-          `UPDATE requests_index
-           SET updated_at = ?, last_event_ts = ?, stage = ?,
-               terminal_state = ?, error_count = ?,
-               last_error_code = ?, last_error_message = ?, last_error_source = ?,
-               retry_count = ?, render_ms = ?, derive_ms = ?, persist_ms = ?,
-               last_trace_id = ?, render_provider = ?, render_fallback_used = ?,
-               render_fallback_reason = ?, degraded = ?, degraded_steps = ?
-           WHERE request_id = ?`
-        )
-          .bind(
-            new Date().toISOString(),
-            lastEvent.ts,
-            finalDerived.stage,
-            finalDerived.terminal ? 1 : 0,
-            finalDerived.errorCount,
-            finalDerived.diagnostics?.errorCode ?? null,
-            finalDerived.diagnostics?.errorMessage ?? null,
-            finalDerived.diagnostics?.errorSource ?? null,
-            finalDerived.diagnostics?.retryCount ?? 0,
-            finalDerived.diagnostics?.renderMs ?? null,
-            finalDerived.diagnostics?.deriveMs ?? null,
-            finalDerived.diagnostics?.persistMs ?? null,
-            finalDerived.diagnostics?.lastTraceId ?? null,
-            finalDerived.diagnostics?.renderProvider ?? null,
-            finalDerived.diagnostics?.renderFallbackUsed === true ? 1 : 0,
-            finalDerived.diagnostics?.renderFallbackReason ?? null,
-            finalDerived.diagnostics?.degraded === true ? 1 : 0,
-            finalDerived.diagnostics?.degradedSteps?.length
-              ? JSON.stringify(finalDerived.diagnostics.degradedSteps)
-              : null,
+        const requestRow = this.sql
+          .exec<Pick<RequestRow, 'request_id' | 'derived_json'>>(
+            'SELECT request_id, derived_json FROM requests WHERE request_id = ? LIMIT 1',
             requestId
           )
-          .run();
-      } catch (err) {
-        console.error(`D1 index batch update failed for ${requestId}:`, err instanceof Error ? err.message : err);
-      }
+          .one();
+        // Same contract as appendEvent: events are stored even when this
+        // instance holds no request row; only the derived update is skipped.
+        const derived: DerivedSummary | undefined = requestRow
+          ? JSON.parse(requestRow.derived_json)
+          : undefined;
+
+        for (const event of events) {
+          const insertRow = this.sql.exec<{ id: number }>(
+            `INSERT INTO events (request_id, ts, source, type, level, message, attempt, data_json)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             RETURNING id`,
+            requestId,
+            event.ts,
+            event.source,
+            event.type,
+            event.level,
+            event.message,
+            event.attempt ?? null,
+            event.data ? JSON.stringify(event.data) : null
+          ).one();
+          eventIds.push(insertRow?.id ?? 0);
+
+          const artifact = artifactFromEvent(event);
+          if (artifact) {
+            this.upsertArtifact(requestId, artifact);
+          }
+
+          if (!derived) continue;
+
+          applyEventToDerived(derived, event);
+        }
+
+        if (requestRow && derived) {
+          this.sql.exec(
+            'UPDATE requests SET derived_json = ? WHERE request_id = ?',
+            JSON.stringify(derived),
+            requestRow.request_id
+          );
+          finalDerived = derived;
+          derivedUpdated = true;
+        }
+      });
+    } catch (err) {
+      console.error(
+        `[logger] appendEvents transaction failed for ${requestId} (${events.length} events):`,
+        err instanceof Error ? err.message : err
+      );
+      throw err; // re-throw so the workflow step can retry
     }
 
-    return { eventIds };
+    // Update D1 index once with the final state (best-effort).
+    // Non-terminal batches skip the best-effort D1 update so they never
+    // race/regress the subsequent terminal event's D1 write (terminals are
+    // sent per-event by design via appendEvent).
+    if (finalDerived?.terminal) {
+      const lastEvent = events[events.length - 1]!;
+      await this.updateD1Index(requestId, lastEvent.ts, finalDerived);
+    }
+
+    return { eventIds, derivedUpdated };
   }
 
   /**

--- a/warg/workers/logger/src/bucket-key.ts
+++ b/warg/workers/logger/src/bucket-key.ts
@@ -6,6 +6,9 @@ export const BUCKET_KEY_PREFIX = 'bucket:';
  */
 export function bucketKeyForTs(isoTs: string): string {
   const d = new Date(isoTs);
+  if (isNaN(d.getTime())) {
+    throw new Error(`bucketKeyForTs: invalid timestamp ${JSON.stringify(isoTs)}`);
+  }
   const y = d.getUTCFullYear();
   const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
   const da = String(d.getUTCDate()).padStart(2, '0');

--- a/warg/workers/logger/src/bucket-key.ts
+++ b/warg/workers/logger/src/bucket-key.ts
@@ -1,0 +1,14 @@
+export const BUCKET_KEY_PREFIX = 'bucket:';
+
+/**
+ * Hour-bucket DO key for a timestamp: `bucket:YYYYMMDDHH` (UTC).
+ * All requests initialized within the same UTC hour share one DO instance.
+ */
+export function bucketKeyForTs(isoTs: string): string {
+  const d = new Date(isoTs);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  return `${BUCKET_KEY_PREFIX}${y}${mo}${da}${h}`;
+}

--- a/warg/workers/logger/src/cloudflare-test-env.d.ts
+++ b/warg/workers/logger/src/cloudflare-test-env.d.ts
@@ -1,7 +1,7 @@
-declare module 'cloudflare:test' {
-  interface ProvidedEnv {
+declare namespace Cloudflare {
+  interface Env {
     LOGGER_DO: DurableObjectNamespace;
     INDEX_DB: D1Database;
-    TEST_MIGRATIONS: D1Migration[];
+    TEST_MIGRATIONS: import('@cloudflare/vitest-pool-workers').D1Migration[];
   }
 }

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -239,7 +239,7 @@ function inferLegacyErrorCode(message: string, source?: string): RequestErrorCod
 
   if (
     lower.includes('execution context was destroyed') ||
-    lower.includes('code\":6000') ||
+    lower.includes('code":6000') ||
     lower.includes('context destroyed')
   ) {
     return 'RENDER_CONTEXT_DESTROYED';

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -675,8 +675,8 @@ async function handleGetStats(env: LoggerServiceEnv): Promise<Response> {
     ).first<{ total: number }>(),
     env.INDEX_DB.prepare(
       `SELECT
-        SUM(CASE WHEN created_at > datetime('now', '-1 hour') THEN 1 ELSE 0 END) as last1h,
-        SUM(CASE WHEN created_at > datetime('now', '-24 hours') THEN 1 ELSE 0 END) as last24h
+        SUM(CASE WHEN created_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-1 hour') THEN 1 ELSE 0 END) as last1h,
+        SUM(CASE WHEN created_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-24 hours') THEN 1 ELSE 0 END) as last24h
       FROM requests_index`
     ).first<{ last1h: number; last24h: number }>(),
     env.INDEX_DB.prepare(
@@ -688,7 +688,7 @@ async function handleGetStats(env: LoggerServiceEnv): Promise<Response> {
     ).all<{ request_id: string; url: string; created_at: string }>(),
     env.INDEX_DB.prepare(
       `SELECT COUNT(*) as count FROM requests_index
-       WHERE terminal_state = 0 AND created_at < datetime('now', '-1 hour')`
+       WHERE terminal_state = 0 AND created_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-1 hour')`
     ).first<{ count: number }>(),
     env.INDEX_DB.prepare(
       `SELECT COUNT(*) as count FROM requests_index
@@ -699,13 +699,13 @@ async function handleGetStats(env: LoggerServiceEnv): Promise<Response> {
       `SELECT COUNT(*) as count FROM requests_index
        WHERE stage = 'queued'
          AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
-         AND created_at < datetime('now', '-10 minutes')`
+         AND created_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-10 minutes')`
     ).first<{ count: number }>(),
     env.INDEX_DB.prepare(
       `SELECT COUNT(*) as count FROM requests_index
        WHERE stage = 'queued'
          AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
-         AND created_at < datetime('now', '-1 hour')`
+         AND created_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-1 hour')`
     ).first<{ count: number }>(),
   ]);
 

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -57,16 +57,25 @@ interface LoggerEventWithId {
 }
 
 interface LoggerStub {
-  initRequest(payload: InitRequestPayload): Promise<{ created: boolean }>;
-  appendEvent(event: LogEvent): Promise<{ eventId: number }>;
-  upsertArtifact(artifact: ArtifactRecord): Promise<void> | void;
-  updateRequestFields(patch: RequestFieldsPatch): Promise<void>;
-  getRequestView(cursor?: number, limit?: number): Promise<CanonicalRequestView | null> | CanonicalRequestView | null;
+  initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
+  appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
+  upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
+  updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
+  getRequestView(
+    requestId: string,
+    cursor?: number,
+    limit?: number
+  ): Promise<CanonicalRequestView | null> | CanonicalRequestView | null;
   getEventsForStream(
+    requestId: string,
     cursor?: number,
     limit?: number
   ): Promise<{ events: LoggerEventWithId[]; derived: DerivedSummary; artifacts: ArtifactRecord[] } | null> | { events: LoggerEventWithId[]; derived: DerivedSummary; artifacts: ArtifactRecord[] } | null;
-  getEvents(cursor?: number, limit?: number): Promise<{ events: LogEvent[]; nextCursor?: number }> | { events: LogEvent[]; nextCursor?: number };
+  getEvents(
+    requestId: string,
+    cursor?: number,
+    limit?: number
+  ): Promise<{ events: LogEvent[]; nextCursor?: number } | null> | { events: LogEvent[]; nextCursor?: number } | null;
 }
 
 const VALID_ERROR_CODES = new Set<RequestErrorCode>([
@@ -390,12 +399,107 @@ function verifyApiKey(request: Request, env: LoggerServiceEnv): boolean {
   return timingSafeEqual(apiKey, env.INTERNAL_API_KEY);
 }
 
+export const BUCKET_KEY_PREFIX = 'bucket:';
+
 /**
- * Get DO stub for a request ID.
+ * Hour-bucket DO key for a timestamp: `bucket:YYYYMMDDHH` (UTC).
+ * All requests initialized within the same UTC hour share one DO instance.
  */
-function getLoggerStub(env: LoggerServiceEnv, requestId: string): LoggerStub {
-  const id = env.LOGGER_DO.idFromName(requestId);
+export function bucketKeyForTs(isoTs: string): string {
+  const d = new Date(isoTs);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  return `${BUCKET_KEY_PREFIX}${y}${mo}${da}${h}`;
+}
+
+function getStubForKey(env: LoggerServiceEnv, key: string): LoggerStub {
+  const id = env.LOGGER_DO.idFromName(key);
   return env.LOGGER_DO.get(id) as unknown as LoggerStub;
+}
+
+/**
+ * Legacy per-request DO stub (pre-bucket keying scheme).
+ * Read/patch fallback only — new writes never target these instances.
+ */
+function getLegacyStub(env: LoggerServiceEnv, requestId: string): LoggerStub {
+  return getStubForKey(env, requestId);
+}
+
+/**
+ * Derive the bucket key a request was initialized under, via the D1 index
+ * (`requests_index.created_at`). Returns null when D1 has no row (the
+ * best-effort index insert failed or has not landed yet). Note pre-bucket
+ * requests ARE indexed, so this returns a key for them too — their bucket DO
+ * just holds no data, which is why readers fall back on a null view.
+ */
+async function getBucketKeyFromD1(
+  env: LoggerServiceEnv,
+  requestId: string
+): Promise<string | null> {
+  const row = await env.INDEX_DB.prepare(
+    'SELECT created_at FROM requests_index WHERE request_id = ?'
+  )
+    .bind(requestId)
+    .first<{ created_at: string }>();
+  return row?.created_at ? bucketKeyForTs(row.created_at) : null;
+}
+
+/**
+ * Stub for post-init writes (events, artifacts). Routes to the bucket of the
+ * request's creation hour so a request's rows never straddle two buckets.
+ * If D1 has no row (best-effort insert failed or raced), fall back to the
+ * current-hour bucket so the write is not lost — never to a legacy DO.
+ */
+async function getBucketStubForWrite(
+  env: LoggerServiceEnv,
+  requestId: string
+): Promise<LoggerStub> {
+  const key = await getBucketKeyFromD1(env, requestId);
+  return getStubForKey(env, key ?? bucketKeyForTs(new Date().toISOString()));
+}
+
+/**
+ * Dual-read: fetch the canonical view from the creation-hour bucket, falling
+ * back to the legacy per-request DO for pre-bucket requests (their D1-derived
+ * bucket DO holds no row for them, so the bucket read returns null).
+ */
+async function readRequestView(
+  env: LoggerServiceEnv,
+  requestId: string,
+  cursor?: number,
+  limit?: number
+): Promise<CanonicalRequestView | null> {
+  const key = await getBucketKeyFromD1(env, requestId);
+  if (key) {
+    const view = await getStubForKey(env, key).getRequestView(requestId, cursor, limit);
+    if (view) return view;
+  }
+  return getLegacyStub(env, requestId).getRequestView(requestId, cursor, limit);
+}
+
+/**
+ * Dual-read stub resolution for the SSE stream, which holds one stub across
+ * its poll loop. Probes the bucket DO first, then the legacy per-request DO.
+ * Returns null when neither knows the request.
+ */
+async function resolveReadStub(
+  env: LoggerServiceEnv,
+  requestId: string
+): Promise<LoggerStub | null> {
+  const key = await getBucketKeyFromD1(env, requestId);
+  if (key) {
+    const stub = getStubForKey(env, key);
+    if ((await stub.getEventsForStream(requestId, undefined, 1)) !== null) {
+      return stub;
+    }
+  }
+  const legacy = getLegacyStub(env, requestId);
+  if ((await legacy.getEventsForStream(requestId, undefined, 1)) !== null) {
+    return legacy;
+  }
+  return null;
 }
 
 /**
@@ -450,42 +554,57 @@ export default {
       // POST /request/init - Initialize a new request
       if (method === 'POST' && path === '/request/init') {
         const payload = (await request.json()) as InitRequestPayload;
-        const stub = getLoggerStub(env, payload.requestId);
-        const result = await stub.initRequest(payload);
+        // The same timestamp picks the bucket AND becomes created_at, so
+        // reads deriving the bucket from created_at can never miss it.
+        const nowIso = new Date().toISOString();
+        const stub = getStubForKey(env, bucketKeyForTs(nowIso));
+        const result = await stub.initRequest(payload, nowIso);
         return Response.json(result, { status: result.created ? 201 : 200 });
       }
 
       // POST /event - Append an event (requires requestId in body)
       if (method === 'POST' && path === '/event') {
         const body = (await request.json()) as { requestId: string; event: LogEvent };
-        const stub = getLoggerStub(env, body.requestId);
-        const result = await stub.appendEvent(body.event);
+        const stub = await getBucketStubForWrite(env, body.requestId);
+        const result = await stub.appendEvent(body.requestId, body.event);
         return Response.json(result);
       }
 
       // POST /artifact - Upsert an artifact (requires requestId in body)
       if (method === 'POST' && path === '/artifact') {
         const body = (await request.json()) as { requestId: string; artifact: ArtifactRecord };
-        const stub = getLoggerStub(env, body.requestId);
-        await stub.upsertArtifact(body.artifact);
+        const stub = await getBucketStubForWrite(env, body.requestId);
+        await stub.upsertArtifact(body.requestId, body.artifact);
         return Response.json({ ok: true });
       }
 
-      // PATCH /request/:id - Update request fields
+      // PATCH /request/:id - Update request fields. Targets the request's
+      // creation-hour bucket; requests still living in a legacy per-request
+      // DO (initialized before the bucket cutover) are patched there.
       if (method === 'PATCH' && path === '/request/:id' && requestId) {
         const patch = (await request.json()) as RequestFieldsPatch;
-        const stub = getLoggerStub(env, requestId);
-        await stub.updateRequestFields(patch);
+        const key = await getBucketKeyFromD1(env, requestId);
+        let updated = false;
+        if (key) {
+          updated = (await getStubForKey(env, key).updateRequestFields(requestId, patch)).updated;
+        }
+        if (!updated) {
+          updated = (await getLegacyStub(env, requestId).updateRequestFields(requestId, patch)).updated;
+        }
+        if (!updated) {
+          return Response.json({ error: 'Request not found' }, { status: 404 });
+        }
         return Response.json({ ok: true });
       }
 
-      // GET /request/:id - Get full request view
+      // GET /request/:id - Get full request view (dual-read)
       if (method === 'GET' && path === '/request/:id' && requestId) {
         const cursor = params.get('cursor');
         const limitParam = params.get('limit');
-        const stub = getLoggerStub(env, requestId);
         const limitVal = Math.min(Math.max(parseInt(limitParam ?? '', 10) || 100, 1), 1000);
-        const view = await stub.getRequestView(
+        const view = await readRequestView(
+          env,
+          requestId,
           cursor ? parseInt(cursor, 10) : undefined,
           limitVal
         );
@@ -495,13 +614,10 @@ export default {
         return Response.json(view);
       }
 
-      // GET /request/:id/stream - SSE event stream
+      // GET /request/:id/stream - SSE event stream (dual-read stub)
       if (method === 'GET' && path === '/request/:id/stream' && requestId) {
-        const stub = getLoggerStub(env, requestId);
-
-        // Check request exists
-        const initial = await stub.getEventsForStream(undefined, 1);
-        if (!initial) {
+        const stub = await resolveReadStub(env, requestId);
+        if (!stub) {
           return Response.json({ error: 'Request not found' }, { status: 404 });
         }
 
@@ -528,7 +644,7 @@ export default {
 
             try {
               // Initial state: fetch request view for metadata
-              const view = await stub.getRequestView();
+              const view = await stub.getRequestView(requestIdCapture);
               if (!view) {
                 send('stream-error', { message: 'Request not found' });
                 controller.close();
@@ -545,7 +661,7 @@ export default {
               });
 
               // Fetch events from cursor (or all events)
-              const data = await stub.getEventsForStream(lastCursor, 500);
+              const data = await stub.getEventsForStream(requestIdCapture, lastCursor, 500);
               if (data) {
                 for (const event of data.events) {
                   send('log', {
@@ -580,7 +696,7 @@ export default {
                   return;
                 }
 
-                const update = await stub.getEventsForStream(lastCursor, 100);
+                const update = await stub.getEventsForStream(requestIdCapture, lastCursor, 100);
                 if (!update) break;
 
                 // Send new events
@@ -632,17 +748,22 @@ export default {
         });
       }
 
-      // GET /request/:id/events - Get paginated events
+      // GET /request/:id/events - Get paginated events (dual-read)
       if (method === 'GET' && path === '/request/:id/events' && requestId) {
         const cursor = params.get('cursor');
         const limitParam = params.get('limit');
-        const stub = getLoggerStub(env, requestId);
         const limitVal = Math.min(Math.max(parseInt(limitParam ?? '', 10) || 100, 1), 1000);
-        const result = await stub.getEvents(
-          cursor ? parseInt(cursor, 10) : undefined,
-          limitVal
-        );
-        return Response.json(result);
+        const cursorVal = cursor ? parseInt(cursor, 10) : undefined;
+
+        const key = await getBucketKeyFromD1(env, requestId);
+        let result = key
+          ? await getStubForKey(env, key).getEvents(requestId, cursorVal, limitVal)
+          : null;
+        if (!result) {
+          result = await getLegacyStub(env, requestId).getEvents(requestId, cursorVal, limitVal);
+        }
+        // Unknown request keeps the historical wire shape: an empty page.
+        return Response.json(result ?? { events: [] });
       }
 
       // GET /stats - Aggregate metrics from D1 index
@@ -799,8 +920,20 @@ export default {
 
         for (const row of candidates.results) {
           try {
-            const stub = getLoggerStub(env, row.request_id);
-            const view = await stub.getRequestView(undefined, 1000);
+            // Dual-read: bucket derived from the row's own created_at, then
+            // the legacy per-request DO for pre-bucket rows.
+            let view = await getStubForKey(env, bucketKeyForTs(row.created_at)).getRequestView(
+              row.request_id,
+              undefined,
+              1000
+            );
+            if (!view) {
+              view = await getLegacyStub(env, row.request_id).getRequestView(
+                row.request_id,
+                undefined,
+                1000
+              );
+            }
             if (!view) {
               skipped++;
               continue;

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -11,6 +11,7 @@ import type {
 import { timingSafeEqual } from '@warg/shared';
 import { bucketKeyForTs } from './bucket-key.js';
 import { LoggerDO } from './LoggerDO.js';
+import { asString, asNumber, asBoolean, asRecord } from './value-helpers.js';
 
 export { LoggerDO };
 
@@ -62,9 +63,9 @@ interface LoggerEventWithId {
 }
 
 interface LoggerStub {
-  initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
+  initRequest(payload: InitRequestPayload, createdAt: string): Promise<{ created: boolean }>;
   appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
-  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }>;
+  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[]; derivedUpdated: boolean }>;
   upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
   updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
   getRequestView(
@@ -153,24 +154,6 @@ function toDiagnostics(row: RequestsIndexRow): RequestDiagnostics {
     degraded: row.degraded === null ? undefined : row.degraded === 1,
     degradedSteps: parseStringArray(row.degraded_steps),
   };
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function defaultRetryableForCode(code: RequestErrorCode): boolean {
@@ -448,6 +431,33 @@ async function getBucketStubForWrite(
   requestId: string
 ): Promise<LoggerStub> {
   const key = await getBucketKeyFromD1(env, requestId);
+  if (key === null) {
+    // H8a: D1 miss — falling back to current-hour bucket; events may be
+    // unresolvable on read if the request was created in a different hour.
+    console.warn(`[logger] getBucketStubForWrite: D1 miss for ${requestId} — using current-hour bucket`);
+
+    // M24: best-effort self-heal — insert a D1 row anchored to now so all
+    // future writes and reads converge on the current-hour bucket.
+    // url/domain are NOT NULL; we use placeholder values since we don't have
+    // the originals here (the canonical values were written by initRequest and
+    // must not be overwritten — INSERT OR IGNORE preserves the original row).
+    const nowIso = new Date().toISOString();
+    try {
+      await env.INDEX_DB.prepare(
+        `INSERT OR IGNORE INTO requests_index
+         (request_id, url, domain, created_at, updated_at, stage)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+        .bind(requestId, '', 'unknown', nowIso, nowIso, 'queued')
+        .run();
+    } catch (err) {
+      // Best-effort: never block the write path
+      console.warn(
+        `[logger] getBucketStubForWrite: self-heal D1 insert failed for ${requestId}:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
   return getStubForKey(env, key ?? bucketKeyForTs(new Date().toISOString()));
 }
 
@@ -466,31 +476,413 @@ async function readRequestView(
   if (key) {
     const view = await getStubForKey(env, key).getRequestView(requestId, cursor, limit);
     if (view) return view;
+    // H8b: D1 had a key but the bucket returned null — bucket miss with a
+    // valid key; falling back to legacy per-request DO.
+    console.warn(`[logger] readRequestView: bucket miss for ${requestId} (key=${key}) — falling back to legacy DO`);
   }
   return getLegacyStub(env, requestId).getRequestView(requestId, cursor, limit);
 }
 
 /**
- * Dual-read stub resolution for the SSE stream, which holds one stub across
- * its poll loop. Probes the bucket DO first, then the legacy per-request DO.
- * Returns null when neither knows the request.
+ * H7: Combined resolver for the SSE stream handshake.
+ * Single D1 lookup → bucket getRequestView → (on null) legacy getRequestView.
+ * Returns both the stub and the already-fetched view so the SSE `init` event
+ * can be sent without a second round-trip.  Returns null when neither DO knows
+ * the request.
+ *
+ * H8b: warns when D1 had a key but the bucket returned null.
  */
-async function resolveReadStub(
+async function resolveReadStubWithView(
   env: LoggerServiceEnv,
   requestId: string
-): Promise<LoggerStub | null> {
+): Promise<{ stub: LoggerStub; view: CanonicalRequestView } | null> {
   const key = await getBucketKeyFromD1(env, requestId);
   if (key) {
     const stub = getStubForKey(env, key);
-    if ((await stub.getEventsForStream(requestId, undefined, 1)) !== null) {
-      return stub;
-    }
+    const view = await stub.getRequestView(requestId);
+    if (view) return { stub, view };
+    // H8b: bucket miss with valid key
+    console.warn(`[logger] resolveReadStubWithView: bucket miss for ${requestId} (key=${key}) — falling back to legacy DO`);
   }
   const legacy = getLegacyStub(env, requestId);
-  if ((await legacy.getEventsForStream(requestId, undefined, 1)) !== null) {
-    return legacy;
-  }
+  const view = await legacy.getRequestView(requestId);
+  if (view) return { stub: legacy, view };
   return null;
+}
+
+/**
+ * SSE stream handler for GET /request/:id/stream.
+ * H7: combined resolver — one D1 lookup + one getRequestView; the
+ * returned view is used directly for the `init` event below.
+ * M2a: bound the resolver so a slow DO wake never hangs the handshake.
+ */
+async function handleSseStream(
+  env: LoggerServiceEnv,
+  requestId: string,
+  reconnectCursor: number | undefined,
+  resolveResult: { stub: LoggerStub; view: CanonicalRequestView }
+): Promise<Response> {
+  const { stub, view: initView } = resolveResult;
+
+  const MAX_STREAM_MS = 2 * 60 * 1000; // 2 minutes
+  const requestIdCapture = requestId;
+  const abortFlag = { stopped: false };
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const streamStart = Date.now();
+      let lastCursor = reconnectCursor;
+
+      const send = (event: string, data: unknown, id?: number) => {
+        let msg = `event: ${event}\n`;
+        if (id !== undefined) msg += `id: ${id}\n`;
+        msg += `data: ${JSON.stringify(data)}\n\n`;
+        controller.enqueue(encoder.encode(msg));
+      };
+
+      try {
+        // H7: use the view already fetched by resolveReadStubWithView —
+        // no second round-trip needed.
+        const view = initView;
+
+        // Send init event with request metadata (always includes artifacts)
+        send('init', {
+          requestId: view.requestId,
+          url: view.url,
+          createdAt: view.createdAt,
+          derived: view.derived,
+          artifacts: view.artifacts,
+        });
+
+        // M15: track last-sent artifacts so state events only include
+        // artifacts when they have changed (cheap JSON.stringify comparison).
+        let lastArtifactsJson = JSON.stringify(view.artifacts);
+
+        // Fetch events from cursor (or all events)
+        const data = await stub.getEventsForStream(requestIdCapture, lastCursor, 500);
+        if (data) {
+          for (const event of data.events) {
+            send('log', {
+              ts: event.ts,
+              source: event.source,
+              type: event.type,
+              level: event.level,
+              message: event.message,
+              attempt: event.attempt,
+              data: event.data,
+            }, event.id);
+            lastCursor = event.id;
+          }
+        }
+
+        // If already terminal, close immediately
+        if (view.derived.terminal) {
+          send('done', {});
+          controller.close();
+          return;
+        }
+
+        // Poll loop: check for new events every 3 seconds
+        while (!abortFlag.stopped) {
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+          if (abortFlag.stopped) break;
+
+          // Enforce max stream duration
+          if (Date.now() - streamStart > MAX_STREAM_MS) {
+            send('timeout', {});
+            controller.close();
+            return;
+          }
+
+          const update = await stub.getEventsForStream(requestIdCapture, lastCursor, 100);
+          if (!update) break;
+
+          // Send new events
+          for (const event of update.events) {
+            send('log', {
+              ts: event.ts,
+              source: event.source,
+              type: event.type,
+              level: event.level,
+              message: event.message,
+              attempt: event.attempt,
+              data: event.data,
+            }, event.id);
+            lastCursor = event.id;
+          }
+
+          // Send state update if there were new events.
+          // M15: only include artifacts when they changed.
+          if (update.events.length > 0) {
+            const newArtifactsJson = JSON.stringify(update.artifacts);
+            const artifactsChanged = newArtifactsJson !== lastArtifactsJson;
+            if (artifactsChanged) {
+              lastArtifactsJson = newArtifactsJson;
+            }
+            send('state', {
+              derived: update.derived,
+              ...(artifactsChanged ? { artifacts: update.artifacts } : {}),
+            });
+          }
+
+          // Close on terminal
+          if (update.derived.terminal) {
+            send('done', {});
+            controller.close();
+            return;
+          }
+        }
+      } catch (err) {
+        console.error(`[logger] SSE stream error for ${requestIdCapture}:`, err);
+      }
+
+      try { controller.close(); } catch { /* already closed */ }
+    },
+    cancel() {
+      abortFlag.stopped = true;
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}
+
+/**
+ * GET /stats handler — aggregate metrics from D1 index.
+ */
+async function handleGetStats(env: LoggerServiceEnv): Promise<Response> {
+  const [
+    stageResult,
+    totalResult,
+    recentResult,
+    domainsResult,
+    failuresResult,
+    stuckResult,
+    orphanQueuedResult,
+    orphanQueuedOlder10mResult,
+    orphanQueuedOlder60mResult
+  ] = await Promise.all([
+    env.INDEX_DB.prepare(
+      'SELECT stage, COUNT(*) as count FROM requests_index GROUP BY stage'
+    ).all<{ stage: string | null; count: number }>(),
+    env.INDEX_DB.prepare(
+      'SELECT COUNT(*) as total FROM requests_index'
+    ).first<{ total: number }>(),
+    env.INDEX_DB.prepare(
+      `SELECT
+        SUM(CASE WHEN created_at > datetime('now', '-1 hour') THEN 1 ELSE 0 END) as last1h,
+        SUM(CASE WHEN created_at > datetime('now', '-24 hours') THEN 1 ELSE 0 END) as last24h
+      FROM requests_index`
+    ).first<{ last1h: number; last24h: number }>(),
+    env.INDEX_DB.prepare(
+      'SELECT domain, COUNT(*) as count FROM requests_index GROUP BY domain ORDER BY count DESC LIMIT 10'
+    ).all<{ domain: string; count: number }>(),
+    env.INDEX_DB.prepare(
+      `SELECT request_id, url, created_at FROM requests_index
+       WHERE stage = 'failed' ORDER BY created_at DESC LIMIT 5`
+    ).all<{ request_id: string; url: string; created_at: string }>(),
+    env.INDEX_DB.prepare(
+      `SELECT COUNT(*) as count FROM requests_index
+       WHERE terminal_state = 0 AND created_at < datetime('now', '-1 hour')`
+    ).first<{ count: number }>(),
+    env.INDEX_DB.prepare(
+      `SELECT COUNT(*) as count FROM requests_index
+       WHERE stage = 'queued'
+         AND (last_event_ts IS NULL OR trim(last_event_ts) = '')`
+    ).first<{ count: number }>(),
+    env.INDEX_DB.prepare(
+      `SELECT COUNT(*) as count FROM requests_index
+       WHERE stage = 'queued'
+         AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
+         AND created_at < datetime('now', '-10 minutes')`
+    ).first<{ count: number }>(),
+    env.INDEX_DB.prepare(
+      `SELECT COUNT(*) as count FROM requests_index
+       WHERE stage = 'queued'
+         AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
+         AND created_at < datetime('now', '-1 hour')`
+    ).first<{ count: number }>(),
+  ]);
+
+  const total = totalResult?.total ?? 0;
+  const byStage: Record<string, number> = {};
+  let doneCount = 0;
+  let failedCount = 0;
+  let activeCount = 0;
+
+  for (const row of stageResult.results) {
+    const stage = row.stage ?? 'unknown';
+    byStage[stage] = row.count;
+    if (stage === 'done') doneCount = row.count;
+    else if (stage === 'failed') failedCount = row.count;
+    else activeCount += row.count;
+  }
+
+  const terminal = doneCount + failedCount;
+  const successRate = terminal > 0 ? doneCount / terminal : 0;
+  const failureRate = terminal > 0 ? failedCount / terminal : 0;
+
+  return Response.json({
+    total,
+    byStage,
+    successRate: Math.round(successRate * 1000) / 1000,
+    failureRate: Math.round(failureRate * 1000) / 1000,
+    activeCount,
+    stuckCount: stuckResult?.count ?? 0,
+    orphanQueue: {
+      total: orphanQueuedResult?.count ?? 0,
+      olderThan10m: orphanQueuedOlder10mResult?.count ?? 0,
+      olderThan60m: orphanQueuedOlder60mResult?.count ?? 0,
+    },
+    recentActivity: {
+      last1h: recentResult?.last1h ?? 0,
+      last24h: recentResult?.last24h ?? 0,
+    },
+    topDomains: domainsResult.results.map((r: { domain: string; count: number }) => ({
+      domain: r.domain,
+      count: r.count,
+    })),
+    recentFailures: failuresResult.results.map((r: { request_id: string; url: string; created_at: string }) => ({
+      requestId: r.request_id,
+      url: r.url,
+      createdAt: r.created_at,
+    })),
+  });
+}
+
+/**
+ * POST /maintenance/backfill-diagnostics handler — recompute missing
+ * diagnostics for legacy rows.
+ */
+async function handleBackfillDiagnostics(
+  env: LoggerServiceEnv,
+  body: { limit?: number; dryRun?: boolean }
+): Promise<Response> {
+  const limit = Math.min(Math.max(body.limit ?? 200, 1), 1000);
+  const dryRun = body.dryRun === true;
+
+  const candidates = await env.INDEX_DB.prepare(
+    `SELECT * FROM requests_index
+     WHERE error_count > 0
+       AND (last_error_code IS NULL OR last_error_message IS NULL OR last_error_source IS NULL)
+     ORDER BY created_at DESC
+     LIMIT ?`
+  ).bind(limit).all<RequestsIndexRow>();
+
+  let updated = 0;
+  let derivedFromEvents = 0;
+  let skipped = 0;
+  const failures: Array<{ requestId: string; error: string }> = [];
+
+  for (const row of candidates.results) {
+    try {
+      // Dual-read: bucket derived from the row's own created_at, then
+      // the legacy per-request DO for pre-bucket rows.
+      // M13: skip rows whose created_at is falsy or unparseable — fall
+      // through to the legacy per-request DO below.
+      let bucketKey: string | null = null;
+      if (row.created_at) {
+        try {
+          bucketKey = bucketKeyForTs(row.created_at);
+        } catch {
+          // invalid timestamp; legacy fallback below
+        }
+      }
+      let view = bucketKey
+        ? await getStubForKey(env, bucketKey).getRequestView(row.request_id, undefined, 1000)
+        : null;
+      if (!view) {
+        view = await getLegacyStub(env, row.request_id).getRequestView(
+          row.request_id,
+          undefined,
+          1000
+        );
+      }
+      if (!view) {
+        skipped++;
+        continue;
+      }
+
+      const existing = view.derived?.diagnostics;
+      const diagnostics =
+        existing?.errorCode && existing?.errorMessage && existing?.errorSource
+          ? existing
+          : recomputeDiagnosticsFromEvents(view.events);
+
+      if (!diagnostics.errorCode && !diagnostics.errorMessage && !diagnostics.errorSource) {
+        skipped++;
+        continue;
+      }
+
+      if (!(existing?.errorCode && existing?.errorMessage && existing?.errorSource)) {
+        derivedFromEvents++;
+      }
+
+      if (!dryRun) {
+        await env.INDEX_DB.prepare(
+          `UPDATE requests_index
+           SET last_error_code = ?,
+               last_error_message = ?,
+               last_error_source = ?,
+               retry_count = ?,
+               render_ms = ?,
+               derive_ms = ?,
+               persist_ms = ?,
+               last_trace_id = ?,
+               render_provider = ?,
+               render_fallback_used = ?,
+               render_fallback_reason = ?,
+               degraded = ?,
+               degraded_steps = ?,
+               updated_at = ?
+           WHERE request_id = ?`
+        )
+          .bind(
+            diagnostics.errorCode ?? null,
+            diagnostics.errorMessage ?? null,
+            diagnostics.errorSource ?? null,
+            diagnostics.retryCount ?? 0,
+            diagnostics.renderMs ?? null,
+            diagnostics.deriveMs ?? null,
+            diagnostics.persistMs ?? null,
+            diagnostics.lastTraceId ?? null,
+            diagnostics.renderProvider ?? null,
+            diagnostics.renderFallbackUsed === undefined
+              ? null
+              : diagnostics.renderFallbackUsed ? 1 : 0,
+            diagnostics.renderFallbackReason ?? null,
+            diagnostics.degraded === undefined ? null : diagnostics.degraded ? 1 : 0,
+            diagnostics.degradedSteps?.length
+              ? JSON.stringify(diagnostics.degradedSteps)
+              : null,
+            new Date().toISOString(),
+            row.request_id
+          )
+          .run();
+      }
+
+      updated++;
+    } catch (err) {
+      failures.push({
+        requestId: row.request_id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return Response.json({
+    dryRun,
+    scanned: candidates.results.length,
+    updated,
+    derivedFromEvents,
+    skipped,
+    failures,
+  });
 }
 
 /**
@@ -556,6 +948,12 @@ export default {
       // POST /event - Append an event (requires requestId in body)
       if (method === 'POST' && path === '/event') {
         const body = (await request.json()) as { requestId: string; event: LogEvent };
+        if (typeof body.requestId !== 'string' || body.requestId.length === 0) {
+          return Response.json(
+            { error: 'Body must contain a non-empty string requestId' },
+            { status: 400 }
+          );
+        }
         const stub = await getBucketStubForWrite(env, body.requestId);
         const result = await stub.appendEvent(body.requestId, body.event);
         return Response.json(result);
@@ -565,11 +963,15 @@ export default {
       // One bucket lookup + one DO round-trip for the whole batch.
       if (method === 'POST' && path === '/events/batch') {
         const body = (await request.json()) as { requestId: string; events: LogEvent[] };
-        if (typeof body.requestId !== 'string' || !Array.isArray(body.events)) {
+        if (typeof body.requestId !== 'string' || body.requestId.length === 0 || !Array.isArray(body.events)) {
           return Response.json(
             { error: 'Body must be { requestId: string, events: LogEvent[] }' },
             { status: 400 }
           );
+        }
+        // M3c: short-circuit empty batch before any DO/bucket lookup
+        if (body.events.length === 0) {
+          return Response.json({ eventIds: [], derivedUpdated: false });
         }
         if (body.events.length > MAX_BATCH_EVENTS) {
           return Response.json(
@@ -579,12 +981,21 @@ export default {
         }
         const stub = await getBucketStubForWrite(env, body.requestId);
         const result = await stub.appendEvents(body.requestId, body.events);
+        if (!result.derivedUpdated) {
+          console.warn(`[logger] appendEvents: no request row found for ${body.requestId} — routing anomaly`);
+        }
         return Response.json(result);
       }
 
       // POST /artifact - Upsert an artifact (requires requestId in body)
       if (method === 'POST' && path === '/artifact') {
         const body = (await request.json()) as { requestId: string; artifact: ArtifactRecord };
+        if (typeof body.requestId !== 'string' || body.requestId.length === 0) {
+          return Response.json(
+            { error: 'Body must contain a non-empty string requestId' },
+            { status: 400 }
+          );
+        }
         const stub = await getBucketStubForWrite(env, body.requestId);
         await stub.upsertArtifact(body.requestId, body.artifact);
         return Response.json({ ok: true });
@@ -628,8 +1039,22 @@ export default {
 
       // GET /request/:id/stream - SSE event stream (dual-read stub)
       if (method === 'GET' && path === '/request/:id/stream' && requestId) {
-        const stub = await resolveReadStub(env, requestId);
-        if (!stub) {
+        // H7: combined resolver — one D1 lookup + one getRequestView; the
+        // returned view is used directly for the `init` event below.
+        // M2a: bound the resolver so a slow DO wake never hangs the handshake.
+        const RESOLVER_TIMEOUT_MS = 10_000;
+        const TIMEOUT_SENTINEL = Symbol('timeout');
+        const resolveTimeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) =>
+          setTimeout(() => resolve(TIMEOUT_SENTINEL), RESOLVER_TIMEOUT_MS)
+        );
+        const resolveResult = await Promise.race([
+          resolveReadStubWithView(env, requestId),
+          resolveTimeout,
+        ]);
+        if (resolveResult === TIMEOUT_SENTINEL) {
+          return Response.json({ error: 'Resolver timeout' }, { status: 503 });
+        }
+        if (!resolveResult) {
           return Response.json({ error: 'Request not found' }, { status: 404 });
         }
 
@@ -638,126 +1063,7 @@ export default {
         const parsed = lastEventIdHeader ? parseInt(lastEventIdHeader, 10) : undefined;
         const reconnectCursor = parsed !== undefined && !Number.isNaN(parsed) ? parsed : undefined;
 
-        const MAX_STREAM_MS = 2 * 60 * 1000; // 2 minutes
-        const requestIdCapture = requestId;
-        const abortFlag = { stopped: false };
-        const stream = new ReadableStream({
-          async start(controller) {
-            const encoder = new TextEncoder();
-            const streamStart = Date.now();
-            let lastCursor = reconnectCursor;
-
-            const send = (event: string, data: unknown, id?: number) => {
-              let msg = `event: ${event}\n`;
-              if (id !== undefined) msg += `id: ${id}\n`;
-              msg += `data: ${JSON.stringify(data)}\n\n`;
-              controller.enqueue(encoder.encode(msg));
-            };
-
-            try {
-              // Initial state: fetch request view for metadata
-              const view = await stub.getRequestView(requestIdCapture);
-              if (!view) {
-                send('stream-error', { message: 'Request not found' });
-                controller.close();
-                return;
-              }
-
-              // Send init event with request metadata
-              send('init', {
-                requestId: view.requestId,
-                url: view.url,
-                createdAt: view.createdAt,
-                derived: view.derived,
-                artifacts: view.artifacts,
-              });
-
-              // Fetch events from cursor (or all events)
-              const data = await stub.getEventsForStream(requestIdCapture, lastCursor, 500);
-              if (data) {
-                for (const event of data.events) {
-                  send('log', {
-                    ts: event.ts,
-                    source: event.source,
-                    type: event.type,
-                    level: event.level,
-                    message: event.message,
-                    attempt: event.attempt,
-                    data: event.data,
-                  }, event.id);
-                  lastCursor = event.id;
-                }
-              }
-
-              // If already terminal, close immediately
-              if (view.derived.terminal) {
-                send('done', {});
-                controller.close();
-                return;
-              }
-
-              // Poll loop: check for new events every 3 seconds
-              while (!abortFlag.stopped) {
-                await new Promise((resolve) => setTimeout(resolve, 3000));
-                if (abortFlag.stopped) break;
-
-                // Enforce max stream duration
-                if (Date.now() - streamStart > MAX_STREAM_MS) {
-                  send('timeout', {});
-                  controller.close();
-                  return;
-                }
-
-                const update = await stub.getEventsForStream(requestIdCapture, lastCursor, 100);
-                if (!update) break;
-
-                // Send new events
-                for (const event of update.events) {
-                  send('log', {
-                    ts: event.ts,
-                    source: event.source,
-                    type: event.type,
-                    level: event.level,
-                    message: event.message,
-                    attempt: event.attempt,
-                    data: event.data,
-                  }, event.id);
-                  lastCursor = event.id;
-                }
-
-                // Send state update if there were new events or state changed
-                if (update.events.length > 0) {
-                  send('state', {
-                    derived: update.derived,
-                    artifacts: update.artifacts,
-                  });
-                }
-
-                // Close on terminal
-                if (update.derived.terminal) {
-                  send('done', {});
-                  controller.close();
-                  return;
-                }
-              }
-            } catch (err) {
-              console.error(`[logger] SSE stream error for ${requestIdCapture}:`, err);
-            }
-
-            try { controller.close(); } catch { /* already closed */ }
-          },
-          cancel() {
-            abortFlag.stopped = true;
-          },
-        });
-
-        return new Response(stream, {
-          headers: {
-            'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache',
-            'Connection': 'keep-alive',
-          },
-        });
+        return handleSseStream(env, requestId, reconnectCursor, resolveResult);
       }
 
       // GET /request/:id/events - Get paginated events (dual-read)
@@ -780,103 +1086,7 @@ export default {
 
       // GET /stats - Aggregate metrics from D1 index
       if (method === 'GET' && path === '/stats') {
-        const [
-          stageResult,
-          totalResult,
-          recentResult,
-          domainsResult,
-          failuresResult,
-          stuckResult,
-          orphanQueuedResult,
-          orphanQueuedOlder10mResult,
-          orphanQueuedOlder60mResult
-        ] = await Promise.all([
-          env.INDEX_DB.prepare(
-            'SELECT stage, COUNT(*) as count FROM requests_index GROUP BY stage'
-          ).all<{ stage: string | null; count: number }>(),
-          env.INDEX_DB.prepare(
-            'SELECT COUNT(*) as total FROM requests_index'
-          ).first<{ total: number }>(),
-          env.INDEX_DB.prepare(
-            `SELECT
-              SUM(CASE WHEN created_at > datetime('now', '-1 hour') THEN 1 ELSE 0 END) as last1h,
-              SUM(CASE WHEN created_at > datetime('now', '-24 hours') THEN 1 ELSE 0 END) as last24h
-            FROM requests_index`
-          ).first<{ last1h: number; last24h: number }>(),
-          env.INDEX_DB.prepare(
-            'SELECT domain, COUNT(*) as count FROM requests_index GROUP BY domain ORDER BY count DESC LIMIT 10'
-          ).all<{ domain: string; count: number }>(),
-          env.INDEX_DB.prepare(
-            `SELECT request_id, url, created_at FROM requests_index
-             WHERE stage = 'failed' ORDER BY created_at DESC LIMIT 5`
-          ).all<{ request_id: string; url: string; created_at: string }>(),
-          env.INDEX_DB.prepare(
-            `SELECT COUNT(*) as count FROM requests_index
-             WHERE terminal_state = 0 AND created_at < datetime('now', '-1 hour')`
-          ).first<{ count: number }>(),
-          env.INDEX_DB.prepare(
-            `SELECT COUNT(*) as count FROM requests_index
-             WHERE stage = 'queued'
-               AND (last_event_ts IS NULL OR trim(last_event_ts) = '')`
-          ).first<{ count: number }>(),
-          env.INDEX_DB.prepare(
-            `SELECT COUNT(*) as count FROM requests_index
-             WHERE stage = 'queued'
-               AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
-               AND created_at < datetime('now', '-10 minutes')`
-          ).first<{ count: number }>(),
-          env.INDEX_DB.prepare(
-            `SELECT COUNT(*) as count FROM requests_index
-             WHERE stage = 'queued'
-               AND (last_event_ts IS NULL OR trim(last_event_ts) = '')
-               AND created_at < datetime('now', '-1 hour')`
-          ).first<{ count: number }>(),
-        ]);
-
-        const total = totalResult?.total ?? 0;
-        const byStage: Record<string, number> = {};
-        let doneCount = 0;
-        let failedCount = 0;
-        let activeCount = 0;
-
-        for (const row of stageResult.results) {
-          const stage = row.stage ?? 'unknown';
-          byStage[stage] = row.count;
-          if (stage === 'done') doneCount = row.count;
-          else if (stage === 'failed') failedCount = row.count;
-          else activeCount += row.count;
-        }
-
-        const terminal = doneCount + failedCount;
-        const successRate = terminal > 0 ? doneCount / terminal : 0;
-        const failureRate = terminal > 0 ? failedCount / terminal : 0;
-
-        return Response.json({
-          total,
-          byStage,
-          successRate: Math.round(successRate * 1000) / 1000,
-          failureRate: Math.round(failureRate * 1000) / 1000,
-          activeCount,
-          stuckCount: stuckResult?.count ?? 0,
-          orphanQueue: {
-            total: orphanQueuedResult?.count ?? 0,
-            olderThan10m: orphanQueuedOlder10mResult?.count ?? 0,
-            olderThan60m: orphanQueuedOlder60mResult?.count ?? 0,
-          },
-          recentActivity: {
-            last1h: recentResult?.last1h ?? 0,
-            last24h: recentResult?.last24h ?? 0,
-          },
-          topDomains: domainsResult.results.map((r: { domain: string; count: number }) => ({
-            domain: r.domain,
-            count: r.count,
-          })),
-          recentFailures: failuresResult.results.map((r: { request_id: string; url: string; created_at: string }) => ({
-            requestId: r.request_id,
-            url: r.url,
-            createdAt: r.created_at,
-          })),
-        });
+        return handleGetStats(env);
       }
 
       // POST /requests/batch - Batch fetch request summaries from D1 index
@@ -914,118 +1124,7 @@ export default {
         const body = await request
           .json()
           .catch(() => ({})) as { limit?: number; dryRun?: boolean };
-        const limit = Math.min(Math.max(body.limit ?? 200, 1), 1000);
-        const dryRun = body.dryRun === true;
-
-        const candidates = await env.INDEX_DB.prepare(
-          `SELECT * FROM requests_index
-           WHERE error_count > 0
-             AND (last_error_code IS NULL OR last_error_message IS NULL OR last_error_source IS NULL)
-           ORDER BY created_at DESC
-           LIMIT ?`
-        ).bind(limit).all<RequestsIndexRow>();
-
-        let updated = 0;
-        let derivedFromEvents = 0;
-        let skipped = 0;
-        const failures: Array<{ requestId: string; error: string }> = [];
-
-        for (const row of candidates.results) {
-          try {
-            // Dual-read: bucket derived from the row's own created_at, then
-            // the legacy per-request DO for pre-bucket rows.
-            let view = await getStubForKey(env, bucketKeyForTs(row.created_at)).getRequestView(
-              row.request_id,
-              undefined,
-              1000
-            );
-            if (!view) {
-              view = await getLegacyStub(env, row.request_id).getRequestView(
-                row.request_id,
-                undefined,
-                1000
-              );
-            }
-            if (!view) {
-              skipped++;
-              continue;
-            }
-
-            const existing = view.derived?.diagnostics;
-            const diagnostics =
-              existing?.errorCode && existing?.errorMessage && existing?.errorSource
-                ? existing
-                : recomputeDiagnosticsFromEvents(view.events);
-
-            if (!diagnostics.errorCode && !diagnostics.errorMessage && !diagnostics.errorSource) {
-              skipped++;
-              continue;
-            }
-
-            if (!(existing?.errorCode && existing?.errorMessage && existing?.errorSource)) {
-              derivedFromEvents++;
-            }
-
-            if (!dryRun) {
-              await env.INDEX_DB.prepare(
-                `UPDATE requests_index
-                 SET last_error_code = ?,
-                     last_error_message = ?,
-                     last_error_source = ?,
-                     retry_count = ?,
-                     render_ms = ?,
-                     derive_ms = ?,
-                     persist_ms = ?,
-                     last_trace_id = ?,
-                     render_provider = ?,
-                     render_fallback_used = ?,
-                     render_fallback_reason = ?,
-                     degraded = ?,
-                     degraded_steps = ?,
-                     updated_at = ?
-                 WHERE request_id = ?`
-              )
-                .bind(
-                  diagnostics.errorCode ?? null,
-                  diagnostics.errorMessage ?? null,
-                  diagnostics.errorSource ?? null,
-                  diagnostics.retryCount ?? 0,
-                  diagnostics.renderMs ?? null,
-                  diagnostics.deriveMs ?? null,
-                  diagnostics.persistMs ?? null,
-                  diagnostics.lastTraceId ?? null,
-                  diagnostics.renderProvider ?? null,
-                  diagnostics.renderFallbackUsed === undefined
-                    ? null
-                    : diagnostics.renderFallbackUsed ? 1 : 0,
-                  diagnostics.renderFallbackReason ?? null,
-                  diagnostics.degraded === undefined ? null : diagnostics.degraded ? 1 : 0,
-                  diagnostics.degradedSteps?.length
-                    ? JSON.stringify(diagnostics.degradedSteps)
-                    : null,
-                  new Date().toISOString(),
-                  row.request_id
-                )
-                .run();
-            }
-
-            updated++;
-          } catch (err) {
-            failures.push({
-              requestId: row.request_id,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          }
-        }
-
-        return Response.json({
-          dryRun,
-          scanned: candidates.results.length,
-          updated,
-          derivedFromEvents,
-          skipped,
-          failures,
-        });
+        return handleBackfillDiagnostics(env, body);
       }
 
       // GET /requests - List requests from D1 index

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -9,6 +9,7 @@ import type {
   RequestErrorCode
 } from '@warg/shared';
 import { timingSafeEqual } from '@warg/shared';
+import { bucketKeyForTs } from './bucket-key.js';
 import { LoggerDO } from './LoggerDO.js';
 
 export { LoggerDO };
@@ -397,21 +398,6 @@ function verifyApiKey(request: Request, env: LoggerServiceEnv): boolean {
   const apiKey = request.headers.get('X-Internal-API-Key');
   if (!apiKey) return false;
   return timingSafeEqual(apiKey, env.INTERNAL_API_KEY);
-}
-
-export const BUCKET_KEY_PREFIX = 'bucket:';
-
-/**
- * Hour-bucket DO key for a timestamp: `bucket:YYYYMMDDHH` (UTC).
- * All requests initialized within the same UTC hour share one DO instance.
- */
-export function bucketKeyForTs(isoTs: string): string {
-  const d = new Date(isoTs);
-  const y = d.getUTCFullYear();
-  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const da = String(d.getUTCDate()).padStart(2, '0');
-  const h = String(d.getUTCHours()).padStart(2, '0');
-  return `${BUCKET_KEY_PREFIX}${y}${mo}${da}${h}`;
 }
 
 function getStubForKey(env: LoggerServiceEnv, key: string): LoggerStub {

--- a/warg/workers/logger/src/index.ts
+++ b/warg/workers/logger/src/index.ts
@@ -14,6 +14,10 @@ import { LoggerDO } from './LoggerDO.js';
 
 export { LoggerDO };
 
+// Cap for POST /events/batch. Producers flush per workflow step (~10–15
+// events max), so this is a guardrail, not an operational limit.
+const MAX_BATCH_EVENTS = 100;
+
 interface RequestsIndexRow {
   request_id: string;
   url: string;
@@ -60,6 +64,7 @@ interface LoggerEventWithId {
 interface LoggerStub {
   initRequest(payload: InitRequestPayload, createdAt?: string): Promise<{ created: boolean }>;
   appendEvent(requestId: string, event: LogEvent): Promise<{ eventId: number }>;
+  appendEvents(requestId: string, events: LogEvent[]): Promise<{ eventIds: number[] }>;
   upsertArtifact(requestId: string, artifact: ArtifactRecord): Promise<void> | void;
   updateRequestFields(requestId: string, patch: RequestFieldsPatch): Promise<{ updated: boolean }>;
   getRequestView(
@@ -498,9 +503,9 @@ function parseRoute(
   const params = url.searchParams;
 
   // Literal routes take priority over parameterized ones
-  if (path === '/request/init' || path === '/event' || path === '/artifact' ||
-      path === '/stats' || path === '/requests' || path === '/requests/batch' ||
-      path === '/maintenance/backfill-diagnostics') {
+  if (path === '/request/init' || path === '/event' || path === '/events/batch' ||
+      path === '/artifact' || path === '/stats' || path === '/requests' ||
+      path === '/requests/batch' || path === '/maintenance/backfill-diagnostics') {
     return { path, params };
   }
 
@@ -553,6 +558,27 @@ export default {
         const body = (await request.json()) as { requestId: string; event: LogEvent };
         const stub = await getBucketStubForWrite(env, body.requestId);
         const result = await stub.appendEvent(body.requestId, body.event);
+        return Response.json(result);
+      }
+
+      // POST /events/batch - Append events atomically (requires requestId in body).
+      // One bucket lookup + one DO round-trip for the whole batch.
+      if (method === 'POST' && path === '/events/batch') {
+        const body = (await request.json()) as { requestId: string; events: LogEvent[] };
+        if (typeof body.requestId !== 'string' || !Array.isArray(body.events)) {
+          return Response.json(
+            { error: 'Body must be { requestId: string, events: LogEvent[] }' },
+            { status: 400 }
+          );
+        }
+        if (body.events.length > MAX_BATCH_EVENTS) {
+          return Response.json(
+            { error: `Batch exceeds ${MAX_BATCH_EVENTS} events` },
+            { status: 400 }
+          );
+        }
+        const stub = await getBucketStubForWrite(env, body.requestId);
+        const result = await stub.appendEvents(body.requestId, body.events);
         return Response.json(result);
       }
 

--- a/warg/workers/logger/src/schema.ts
+++ b/warg/workers/logger/src/schema.ts
@@ -1,6 +1,10 @@
 /**
  * DO SQLite schema for request traces.
- * Each Durable Object instance stores one request's data.
+ *
+ * Keying scheme: each Durable Object instance is an hour bucket
+ * (`bucket:YYYYMMDDHH` UTC) holding every request initialized in that hour.
+ * Pre-bucket instances (keyed by request_id, one request per DO) still exist
+ * and are served read-only via the dual-read fallback in index.ts.
  */
 
 /**
@@ -21,6 +25,7 @@ export function initSchema(sql: SqlStorage): void {
 
     CREATE TABLE IF NOT EXISTS events (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
+      request_id TEXT NOT NULL DEFAULT '',
       ts TEXT NOT NULL,
       source TEXT NOT NULL,
       type TEXT NOT NULL,
@@ -31,6 +36,7 @@ export function initSchema(sql: SqlStorage): void {
     );
 
     CREATE TABLE IF NOT EXISTS artifacts (
+      request_id TEXT NOT NULL DEFAULT '',
       kind TEXT NOT NULL,
       r2_key TEXT NOT NULL,
       content_type TEXT NOT NULL,
@@ -43,4 +49,48 @@ export function initSchema(sql: SqlStorage): void {
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
   `);
+  // The request_id indexes live in migrateSchema: on legacy instances the
+  // column does not exist until migrateSchema adds it, and ensureSchema
+  // always runs migrateSchema immediately after initSchema.
+}
+
+/**
+ * Migrate a pre-bucket DO instance to the multi-request layout.
+ *
+ * Bucket DOs hold many requests, so `events` and `artifacts` need a
+ * `request_id` column. Legacy per-request instances stored exactly one
+ * request, so their rows are adopted under that request's id, letting every
+ * read path filter on `request_id` uniformly across old and new instances.
+ *
+ * Idempotent: each statement either no-ops (IF NOT EXISTS, 0 rows matched)
+ * or fails with "duplicate column name", which is swallowed; anything else
+ * is rethrown.
+ */
+export function migrateSchema(sql: SqlStorage): void {
+  addColumnIfMissing(sql, 'events', "request_id TEXT NOT NULL DEFAULT ''");
+  addColumnIfMissing(sql, 'artifacts', "request_id TEXT NOT NULL DEFAULT ''");
+  sql.exec(`CREATE INDEX IF NOT EXISTS idx_events_request_id ON events(request_id)`);
+  sql.exec(`CREATE INDEX IF NOT EXISTS idx_artifacts_request_id ON artifacts(request_id)`);
+  // Legacy per-request instances hold exactly one requests row; adopt all
+  // unattributed rows under it. No-op on bucket instances (writes there
+  // always carry request_id) and on empty instances (no rows match).
+  sql.exec(
+    `UPDATE events SET request_id = COALESCE((SELECT request_id FROM requests LIMIT 1), '')
+     WHERE request_id = ''`
+  );
+  sql.exec(
+    `UPDATE artifacts SET request_id = COALESCE((SELECT request_id FROM requests LIMIT 1), '')
+     WHERE request_id = ''`
+  );
+}
+
+function addColumnIfMissing(sql: SqlStorage, table: string, columnDef: string): void {
+  try {
+    sql.exec(`ALTER TABLE ${table} ADD COLUMN ${columnDef}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('duplicate column')) {
+      throw err;
+    }
+  }
 }

--- a/warg/workers/logger/src/schema.ts
+++ b/warg/workers/logger/src/schema.ts
@@ -10,6 +10,7 @@
 /**
  * Initialize the DO SQLite schema.
  * Creates tables if they don't exist.
+ * New instances get the correct shape directly (PK includes request_id).
  */
 export function initSchema(sql: SqlStorage): void {
   sql.exec(`
@@ -43,11 +44,14 @@ export function initSchema(sql: SqlStorage): void {
       bytes INTEGER NOT NULL,
       sha256 TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (kind, r2_key)
+      PRIMARY KEY (request_id, kind, r2_key)
     );
 
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+    -- Sentinel: presence of this index signals that artifacts already has the
+    -- correct PK (request_id, kind, r2_key), so migrateSchema skips the rebuild.
+    CREATE INDEX IF NOT EXISTS idx_artifacts_pk_rebuilt ON artifacts(kind);
   `);
   // The request_id indexes live in migrateSchema: on legacy instances the
   // column does not exist until migrateSchema adds it, and ensureSchema
@@ -62,6 +66,21 @@ export function initSchema(sql: SqlStorage): void {
  * request, so their rows are adopted under that request's id, letting every
  * read path filter on `request_id` uniformly across old and new instances.
  *
+ * H5: Legacy artifacts table has PK (kind, r2_key) which is too coarse for
+ * multi-request instances — different requests could collide.  We rebuild the
+ * table with PK (request_id, kind, r2_key) when the old narrow PK is still in
+ * place.  The rebuild is guarded by checking whether the index
+ * `idx_artifacts_pk_rebuilt` already exists so it runs at most once per
+ * instance (idempotent across cold starts).
+ *
+ * H6: The legacy-row adoption UPDATE is guarded: if the instance somehow holds
+ * more than one request row we skip adoption (rows stay request_id='') rather
+ * than mis-assigning them; a deterministic ORDER BY is used when we do adopt.
+ *
+ * M8: The adoption UPDATEs are skipped cheaply when no unattributed rows exist
+ * (COUNT(*)=0 guard), so post-migration cold starts hit an index-assisted
+ * zero-row check instead of a full table-scan UPDATE.
+ *
  * Idempotent: each statement either no-ops (IF NOT EXISTS, 0 rows matched)
  * or fails with "duplicate column name", which is swallowed; anything else
  * is rethrown.
@@ -71,17 +90,105 @@ export function migrateSchema(sql: SqlStorage): void {
   addColumnIfMissing(sql, 'artifacts', "request_id TEXT NOT NULL DEFAULT ''");
   sql.exec(`CREATE INDEX IF NOT EXISTS idx_events_request_id ON events(request_id)`);
   sql.exec(`CREATE INDEX IF NOT EXISTS idx_artifacts_request_id ON artifacts(request_id)`);
-  // Legacy per-request instances hold exactly one requests row; adopt all
-  // unattributed rows under it. No-op on bucket instances (writes there
-  // always carry request_id) and on empty instances (no rows match).
-  sql.exec(
-    `UPDATE events SET request_id = COALESCE((SELECT request_id FROM requests LIMIT 1), '')
-     WHERE request_id = ''`
-  );
-  sql.exec(
-    `UPDATE artifacts SET request_id = COALESCE((SELECT request_id FROM requests LIMIT 1), '')
-     WHERE request_id = ''`
-  );
+
+  // H5: Rebuild artifacts table if it still has the old narrow PK (kind, r2_key).
+  // We detect this by the absence of our sentinel index `idx_artifacts_pk_rebuilt`.
+  // New instances created by initSchema already have PK (request_id, kind, r2_key)
+  // and do not need the rebuild, but we create the sentinel there too so the check
+  // is always fast.
+  const rebuildDone = sql
+    .exec<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM sqlite_master
+       WHERE type='index' AND name='idx_artifacts_pk_rebuilt'`
+    )
+    .one();
+
+  if (!rebuildDone || rebuildDone.cnt === 0) {
+    // Rebuild artifacts with the correct PK. This is safe to run when the table
+    // is empty (new instance that went through initSchema with the old PK) or
+    // when it has rows (legacy instance — rows already have request_id populated
+    // by the addColumnIfMissing step above, defaulting to '').
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS artifacts_new (
+        request_id TEXT NOT NULL DEFAULT '',
+        kind TEXT NOT NULL,
+        r2_key TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        bytes INTEGER NOT NULL,
+        sha256 TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (request_id, kind, r2_key)
+      )
+    `);
+    sql.exec(`
+      INSERT OR IGNORE INTO artifacts_new
+        SELECT request_id, kind, r2_key, content_type, bytes, sha256, created_at
+        FROM artifacts
+    `);
+    sql.exec(`DROP TABLE artifacts`);
+    sql.exec(`ALTER TABLE artifacts_new RENAME TO artifacts`);
+    // Recreate indexes after rename (RENAME does not carry named indexes from the old table).
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_artifacts_request_id ON artifacts(request_id)`);
+    // Sentinel index: its presence in sqlite_master means the rebuild has already run.
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_artifacts_pk_rebuilt ON artifacts(kind)`);
+  }
+
+  // H6 + M8: Legacy row adoption for events.
+  // M8 cheap guard: skip if there are no unattributed event rows.
+  const orphanEvents = sql
+    .exec<{ cnt: number }>(`SELECT COUNT(*) AS cnt FROM events WHERE request_id = ''`)
+    .one();
+
+  if (orphanEvents && orphanEvents.cnt > 0) {
+    // H6: Only adopt when the instance holds exactly one request row.
+    // If it holds more than one, skip rather than mis-assign.
+    const requestCount = sql
+      .exec<{ cnt: number }>(`SELECT COUNT(*) AS cnt FROM requests`)
+      .one();
+
+    if (requestCount && requestCount.cnt > 1) {
+      console.error(
+        `[logger] migrateSchema: legacy DO holds ${requestCount.cnt} requests, skipping event adoption`
+      );
+    } else {
+      // ORDER BY created_at ASC LIMIT 1 for determinism.
+      sql.exec(
+        `UPDATE events
+         SET request_id = COALESCE(
+           (SELECT request_id FROM requests ORDER BY created_at ASC LIMIT 1), ''
+         )
+         WHERE request_id = ''`
+      );
+    }
+  }
+
+  // H6 + M8: Legacy row adoption for artifacts.
+  // M8 cheap guard: skip if there are no unattributed artifact rows.
+  // A partial failure on events (above) self-heals on next cold start because
+  // the WHERE request_id='' predicate is idempotent.
+  const orphanArtifacts = sql
+    .exec<{ cnt: number }>(`SELECT COUNT(*) AS cnt FROM artifacts WHERE request_id = ''`)
+    .one();
+
+  if (orphanArtifacts && orphanArtifacts.cnt > 0) {
+    const requestCount = sql
+      .exec<{ cnt: number }>(`SELECT COUNT(*) AS cnt FROM requests`)
+      .one();
+
+    if (requestCount && requestCount.cnt > 1) {
+      console.error(
+        `[logger] migrateSchema: legacy DO holds ${requestCount.cnt} requests, skipping artifact adoption`
+      );
+    } else {
+      sql.exec(
+        `UPDATE artifacts
+         SET request_id = COALESCE(
+           (SELECT request_id FROM requests ORDER BY created_at ASC LIMIT 1), ''
+         )
+         WHERE request_id = ''`
+      );
+    }
+  }
 }
 
 function addColumnIfMissing(sql: SqlStorage, table: string, columnDef: string): void {

--- a/warg/workers/logger/src/schema.ts
+++ b/warg/workers/logger/src/schema.ts
@@ -196,7 +196,7 @@ function addColumnIfMissing(sql: SqlStorage, table: string, columnDef: string): 
     sql.exec(`ALTER TABLE ${table} ADD COLUMN ${columnDef}`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (!message.includes('duplicate column')) {
+    if (!message.toLowerCase().includes('duplicate column')) {
       throw err;
     }
   }

--- a/warg/workers/logger/src/value-helpers.ts
+++ b/warg/workers/logger/src/value-helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared coercion helpers for safe extraction of typed values from unknown data.
+ * Used by LoggerDO.ts and index.ts.
+ */
+
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/warg/workers/logger/tsconfig.json
+++ b/warg/workers/logger/tsconfig.json
@@ -8,5 +8,9 @@
       "./worker-configuration.d.ts"
     ]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "../../node_modules/@cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts"
+  ]
 }

--- a/warg/workers/logger/vitest.config.ts
+++ b/warg/workers/logger/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(async () => {
       cloudflareTest({
         wrangler: { configPath: './wrangler.jsonc' },
         miniflare: {
-          bindings: { TEST_MIGRATIONS: migrations }
+          bindings: { TEST_MIGRATIONS: migrations, INTERNAL_API_KEY: 'verify-test-key-local-only' }
         }
       })
     ],

--- a/warg/workers/logger/vitest.config.ts
+++ b/warg/workers/logger/vitest.config.ts
@@ -1,24 +1,22 @@
 import path from 'node:path';
-import {
-  defineWorkersConfig,
-  readD1Migrations
-} from '@cloudflare/vitest-pool-workers/config';
+import { defineConfig } from 'vitest/config';
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
 
-export default defineWorkersConfig(async () => {
+export default defineConfig(async () => {
   const migrationsPath = path.join(__dirname, 'migrations');
   const migrations = await readD1Migrations(migrationsPath);
 
   return {
+    plugins: [
+      cloudflareTest({
+        wrangler: { configPath: './wrangler.jsonc' },
+        miniflare: {
+          bindings: { TEST_MIGRATIONS: migrations }
+        }
+      })
+    ],
     test: {
       setupFiles: ['./src/test-setup.ts'],
-      poolOptions: {
-        workers: {
-          wrangler: { configPath: './wrangler.jsonc' },
-          miniflare: {
-            bindings: { TEST_MIGRATIONS: migrations }
-          }
-        }
-      }
     }
   };
 });

--- a/warg/workers/monolith/README.md
+++ b/warg/workers/monolith/README.md
@@ -1,0 +1,44 @@
+# monolith
+
+Produces self-contained `monolith.html` from rendered HTML, running the
+monolith binary inside a Cloudflare Sandbox container. Internal worker
+(`X-Internal-API-Key` required).
+
+## Container lifecycle
+
+Containers bill Durable Object duration the entire time they are alive, so
+they are stopped per job — there is no warm pool. Sandboxes are keyed off the
+request id (`normalizeSandboxId(requestId)`), and each job cold-starts its
+container. Rationale and cost numbers:
+[`docs/adr-do-cost.md`](../../docs/adr-do-cost.md).
+
+Three layers guarantee shutdown:
+
+1. **`stop()` per job** — `runMonolithInSandbox` wraps execution in
+   `try/finally` and stops the sandbox on success and on error. A failing
+   `stop()` is logged (`[monolith] stop() failed (non-fatal)`) and never
+   masks the job's outcome.
+2. **30s `sleepAfter` backstop** — the `Sandbox` subclass exported from
+   `src/index.ts` sets `sleepAfter = '30s'` (upstream default is 10 minutes).
+   Wrangler's `containers` config has no `sleep_after` key; the class field
+   is the configuration surface.
+3. **Cron orphan sweep** — the gateway's 10-minute cron stops containers
+   behind sandbox quota leases that outlived the 5-minute lease TTL, via
+   `POST /container/stop` here.
+
+## Endpoints
+
+| Route | Notes |
+|---|---|
+| `POST /monolith` | `{ request_id, rendered_html_key, base_url }` → runs the job; HTML moves via presigned R2 URLs, never through worker RPC |
+| `POST /container/stop` | `{ request_id }` → stops that request's container; used by the gateway sweep |
+
+## Tests
+
+```bash
+pnpm --filter @warg/monolith test
+```
+
+`monolith-lifecycle.test.ts` asserts `stop()` fires exactly once on the
+success, exec-failure, and upload-failure paths, and that `stop()` failures
+mask nothing.

--- a/warg/workers/monolith/README.md
+++ b/warg/workers/monolith/README.md
@@ -18,8 +18,10 @@ Three layers guarantee shutdown:
    `try/finally` and stops the sandbox on success and on error. A failing
    `stop()` is logged (`[monolith] stop() failed (non-fatal)`) and never
    masks the job's outcome.
-2. **30s `sleepAfter` backstop** — the `Sandbox` subclass exported from
-   `src/index.ts` sets `sleepAfter = '30s'` (upstream default is 10 minutes).
+2. **5m `sleepAfter` backstop** — the `Sandbox` subclass exported from
+   `src/index.ts` sets `sleepAfter = '5m'` (upstream default is 10 minutes).
+   The value must exceed the longest job (P99 ~180s) because the inactivity
+   alarm fires even during an in-flight exec (cloudflare/containers#162).
    Wrangler's `containers` config has no `sleep_after` key; the class field
    is the configuration surface.
 3. **Cron orphan sweep** — the gateway's 10-minute cron stops containers

--- a/warg/workers/monolith/package.json
+++ b/warg/workers/monolith/package.json
@@ -16,6 +16,6 @@
     "aws4fetch": "^1.0.20"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/monolith/src/index.ts
+++ b/warg/workers/monolith/src/index.ts
@@ -1,4 +1,4 @@
-import { getSandbox } from '@cloudflare/sandbox';
+import { getSandbox, Sandbox as BaseSandbox } from '@cloudflare/sandbox';
 import { getR2Key, storeArtifact, timingSafeEqual, type ArtifactMeta } from '@warg/shared';
 import type { MonolithRequest, MonolithSuccessResponse } from './types.js';
 import {
@@ -12,8 +12,17 @@ import {
 import { presignR2GetUrl, presignR2PutUrl, type R2PresignConfig } from './r2-presign.js';
 import { isRpc32MiBLimit } from './failure-classify.js';
 
-// Re-export Sandbox for Durable Object binding
-export { Sandbox } from '@cloudflare/sandbox';
+/**
+ * Sandbox DO binding with a 30s `sleepAfter` backstop (the upstream default
+ * is 10 minutes). The primary lifecycle mechanism is the explicit `stop()`
+ * after each job in runMonolithInSandbox; this backstop reaps containers
+ * whose stop() was missed (worker crash mid-job, stop() RPC failure) so they
+ * cannot idle-bill DO duration. Wrangler's `containers` config exposes no
+ * sleep_after key, so the class field is the configuration surface.
+ */
+export class Sandbox extends BaseSandbox {
+  override sleepAfter: string | number = '30s';
+}
 
 class MonolithServiceError extends Error {
   readonly code: string;
@@ -177,109 +186,116 @@ function getPresignConfig(env: Env): R2PresignConfig {
  * writes inside the container (normal fs) and feeds monolith a local path.
  * Neither path uses the host→container `writeFile` RPC that was 500ing.
  */
-async function runMonolithInSandbox(
+export async function runMonolithInSandbox(
   env: Env,
   requestId: string,
   renderedHtmlKey: string,
-  baseUrl: string,
-  poolSandboxId?: string
+  baseUrl: string
 ): Promise<{ artifact: ArtifactMeta; sandboxId: string }> {
   const normalizedBaseUrl = validateBaseUrl(baseUrl);
-  // Prefer the warm-pool sandbox assigned by the workflow, but only if it is a
-  // well-formed pool id — otherwise fall back to a per-request sandbox so a
-  // malformed value can't funnel every job onto one shared container.
-  const usesPool = poolSandboxId !== undefined && /^monolith-pool-\d+$/.test(poolSandboxId);
-  const sandboxId = normalizeSandboxId(usesPool ? poolSandboxId! : requestId);
+  const sandboxId = normalizeSandboxId(requestId);
   console.log('[monolith] Getting sandbox for request:', requestId, 'sandbox:', sandboxId);
   const sandbox = getSandbox(env.Sandbox, sandboxId);
 
-  // Warm-pool sandboxes are reused across requests, so clear any prior output
-  // before this run. Folded into the exec strings (no extra RPC); monolith's
-  // `-o` also truncates, this just closes the success-but-stale edge.
-  const cleanOut = `rm -f ${SANDBOX_OUTPUT_PATH}`;
+  try {
+    // Retry attempts can land on the same per-request container within the
+    // sleepAfter window, so clear any prior output before this run. Folded
+    // into the exec strings (no extra RPC); monolith's `-o` also truncates,
+    // this just closes the success-but-stale edge.
+    const cleanOut = `rm -f ${SANDBOX_OUTPUT_PATH}`;
 
-  // Mint a short-lived presigned GET URL for the rendered HTML. Never logged —
-  // it grants read access to the object for its TTL.
-  const documentUrl = await presignR2GetUrl(getPresignConfig(env), renderedHtmlKey);
+    // Mint a short-lived presigned GET URL for the rendered HTML. Never logged —
+    // it grants read access to the object for its TTL.
+    const documentUrl = await presignR2GetUrl(getPresignConfig(env), renderedHtmlKey);
 
-  // Primary: monolith fetches the URL directly (no curl dependency).
-  console.log('[monolith] Executing monolith via presigned URL fetch...');
-  let result = await execInSandbox(
-    sandbox,
-    `${cleanOut}; ${buildMonolithUrlCommand(documentUrl, normalizedBaseUrl)}`
-  );
+    // Primary: monolith fetches the URL directly (no curl dependency).
+    console.log('[monolith] Executing monolith via presigned URL fetch...');
+    let result = await execInSandbox(
+      sandbox,
+      `${cleanOut}; ${buildMonolithUrlCommand(documentUrl, normalizedBaseUrl)}`
+    );
 
-  // Fallback: curl the URL into a local file, then monolith reads the file.
-  if (!result.success) {
-    console.warn('[monolith] URL-fetch path failed, trying curl-to-file fallback', {
-      exitCode: result.exitCode,
-      stderr: result.stderr.slice(0, 500)
-    });
-    const curl = await execInSandbox(sandbox, buildCurlCommand(documentUrl));
-    if (curl.success) {
-      result = await execInSandbox(
-        sandbox,
-        `${cleanOut}; ${buildMonolithFileCommand(normalizedBaseUrl)}`
-      );
-    } else {
-      console.error('[monolith] curl fallback failed', {
-        exitCode: curl.exitCode,
-        stderr: curl.stderr.slice(0, 500)
+    // Fallback: curl the URL into a local file, then monolith reads the file.
+    if (!result.success) {
+      console.warn('[monolith] URL-fetch path failed, trying curl-to-file fallback', {
+        exitCode: result.exitCode,
+        stderr: result.stderr.slice(0, 500)
       });
+      const curl = await execInSandbox(sandbox, buildCurlCommand(documentUrl));
+      if (curl.success) {
+        result = await execInSandbox(
+          sandbox,
+          `${cleanOut}; ${buildMonolithFileCommand(normalizedBaseUrl)}`
+        );
+      } else {
+        console.error('[monolith] curl fallback failed', {
+          exitCode: curl.exitCode,
+          stderr: curl.stderr.slice(0, 500)
+        });
+      }
+    }
+
+    if (!result.success) {
+      console.error('[monolith] Execution failed:', {
+        exitCode: result.exitCode,
+        stderr: result.stderr,
+        stdout: result.stdout
+      });
+      throw classifySandboxFailure(result.stderr, result.stdout);
+    }
+
+    // Upload the output straight to R2 via a presigned PUT URL, then read back its
+    // sha256 + byte size from stdout. Routing the bytes over the container network
+    // sidesteps the 32 MiB `readFile` RPC ceiling that heavy (base64-inlined)
+    // pages would otherwise overflow.
+    console.log('[monolith] Execution complete, uploading output to R2...');
+    const r2Key = getR2Key(requestId, 'monolith.html');
+    const putUrl = await presignR2PutUrl(getPresignConfig(env), r2Key);
+    const upload = await execInSandbox(sandbox, buildUploadAndHashCommand(putUrl));
+    if (!upload.success) {
+      console.error('[monolith] Output upload failed:', {
+        exitCode: upload.exitCode,
+        stderr: upload.stderr.slice(0, 500)
+      });
+      throw classifySandboxFailure(upload.stderr, upload.stdout);
+    }
+
+    const parsed = parseUploadOutput(upload.stdout);
+    if (!parsed) {
+      throw new MonolithServiceError(
+        'Monolith output upload did not report sha256/size',
+        'MONOLITH_SANDBOX_500',
+        500,
+        true
+      );
+    }
+    if (parsed.bytes === 0) {
+      throw new MonolithServiceError(
+        'Monolith produced empty output',
+        'MONOLITH_EMPTY_OUTPUT',
+        500,
+        false
+      );
+    }
+
+    const artifact: ArtifactMeta = {
+      kind: 'monolith.html',
+      r2Key,
+      bytes: parsed.bytes,
+      sha256: parsed.sha256,
+      contentType: 'text/html'
+    };
+    return { artifact, sandboxId };
+  } finally {
+    // Containers bill DO duration while alive: stop per job, on success AND
+    // throw. A failed stop() must not mask the job's own outcome — the 30s
+    // sleepAfter backstop and the cron orphan sweep cover missed stops.
+    try {
+      await sandbox.stop();
+    } catch (stopErr) {
+      console.warn('[monolith] stop() failed (non-fatal):', stopErr);
     }
   }
-
-  if (!result.success) {
-    console.error('[monolith] Execution failed:', {
-      exitCode: result.exitCode,
-      stderr: result.stderr,
-      stdout: result.stdout
-    });
-    throw classifySandboxFailure(result.stderr, result.stdout);
-  }
-
-  // Upload the output straight to R2 via a presigned PUT URL, then read back its
-  // sha256 + byte size from stdout. Routing the bytes over the container network
-  // sidesteps the 32 MiB `readFile` RPC ceiling that heavy (base64-inlined)
-  // pages would otherwise overflow.
-  console.log('[monolith] Execution complete, uploading output to R2...');
-  const r2Key = getR2Key(requestId, 'monolith.html');
-  const putUrl = await presignR2PutUrl(getPresignConfig(env), r2Key);
-  const upload = await execInSandbox(sandbox, buildUploadAndHashCommand(putUrl));
-  if (!upload.success) {
-    console.error('[monolith] Output upload failed:', {
-      exitCode: upload.exitCode,
-      stderr: upload.stderr.slice(0, 500)
-    });
-    throw classifySandboxFailure(upload.stderr, upload.stdout);
-  }
-
-  const parsed = parseUploadOutput(upload.stdout);
-  if (!parsed) {
-    throw new MonolithServiceError(
-      'Monolith output upload did not report sha256/size',
-      'MONOLITH_SANDBOX_500',
-      500,
-      true
-    );
-  }
-  if (parsed.bytes === 0) {
-    throw new MonolithServiceError(
-      'Monolith produced empty output',
-      'MONOLITH_EMPTY_OUTPUT',
-      500,
-      false
-    );
-  }
-
-  const artifact: ArtifactMeta = {
-    kind: 'monolith.html',
-    r2Key,
-    bytes: parsed.bytes,
-    sha256: parsed.sha256,
-    contentType: 'text/html'
-  };
-  return { artifact, sandboxId };
 }
 
 /**
@@ -319,7 +335,10 @@ export default {
     try {
       const url = new URL(request.url);
 
-      if (request.method !== 'POST' || url.pathname !== '/monolith') {
+      const isKnownRoute =
+        request.method === 'POST' &&
+        (url.pathname === '/monolith' || url.pathname === '/container/stop');
+      if (!isKnownRoute) {
         return Response.json({ error: 'Not found' }, { status: 404 });
       }
 
@@ -327,6 +346,23 @@ export default {
       const apiKey = request.headers.get('X-Internal-API-Key');
       if (!apiKey || !timingSafeEqual(apiKey, env.INTERNAL_API_KEY)) {
         return Response.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      // POST /container/stop - stop a request's container (gateway orphan sweep)
+      if (url.pathname === '/container/stop') {
+        let stopBody: { request_id?: string };
+        try {
+          stopBody = (await request.json()) as { request_id?: string };
+        } catch {
+          return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+        }
+        if (!stopBody.request_id) {
+          return Response.json({ error: 'Missing required field: request_id' }, { status: 400 });
+        }
+        const sandboxId = normalizeSandboxId(stopBody.request_id);
+        await getSandbox(env.Sandbox, sandboxId).stop();
+        console.log('[monolith] Stopped container via /container/stop:', sandboxId);
+        return Response.json({ ok: true, sandboxId });
       }
 
       // Parse request body
@@ -374,8 +410,7 @@ export default {
           env,
           request_id,
           rendered_html_key,
-          base_url,
-          body.sandbox_id
+          base_url
         );
         artifact = sandboxResult.artifact;
         sandboxId = sandboxResult.sandboxId;

--- a/warg/workers/monolith/src/index.ts
+++ b/warg/workers/monolith/src/index.ts
@@ -13,15 +13,18 @@ import { presignR2GetUrl, presignR2PutUrl, type R2PresignConfig } from './r2-pre
 import { isRpc32MiBLimit } from './failure-classify.js';
 
 /**
- * Sandbox DO binding with a 30s `sleepAfter` backstop (the upstream default
+ * Sandbox DO binding with a 5m `sleepAfter` backstop (the upstream default
  * is 10 minutes). The primary lifecycle mechanism is the explicit `stop()`
  * after each job in runMonolithInSandbox; this backstop reaps containers
  * whose stop() was missed (worker crash mid-job, stop() RPC failure) so they
- * cannot idle-bill DO duration. Wrangler's `containers` config exposes no
- * sleep_after key, so the class field is the configuration surface.
+ * cannot idle-bill DO duration. The value must exceed the longest job
+ * (P99 ~180s) because the inactivity alarm fires even during an in-flight
+ * exec (cloudflare/containers#162) — '5m' clears that tail with margin.
+ * Wrangler's `containers` config exposes no sleep_after key, so the class
+ * field is the configuration surface.
  */
 export class Sandbox extends BaseSandbox {
-  override sleepAfter: string | number = '30s';
+  override sleepAfter: string | number = '5m';
 }
 
 class MonolithServiceError extends Error {
@@ -289,7 +292,7 @@ export async function runMonolithInSandbox(
     return { artifact, sandboxId };
   } finally {
     // Containers bill DO duration while alive: stop per job, on success AND
-    // throw. A failed stop() must not mask the job's own outcome — the 30s
+    // throw. A failed stop() must not mask the job's own outcome — the 5m
     // sleepAfter backstop and the cron orphan sweep cover missed stops.
     try {
       await sandbox.stop();

--- a/warg/workers/monolith/src/index.ts
+++ b/warg/workers/monolith/src/index.ts
@@ -297,7 +297,7 @@ export async function runMonolithInSandbox(
     try {
       await sandbox.stop();
     } catch (stopErr) {
-      console.warn('[monolith] stop() failed (non-fatal):', stopErr);
+      console.warn(`[monolith] stop() failed for ${requestId} (sandbox: ${sandboxId}) — non-fatal, sleepAfter backstop covers:`, stopErr);
     }
   }
 }
@@ -364,9 +364,18 @@ export default {
           return Response.json({ error: 'Missing required field: request_id' }, { status: 400 });
         }
         const sandboxId = normalizeSandboxId(stopBody.request_id);
-        await getSandbox(env.Sandbox, sandboxId).stop();
-        console.log('[monolith] Stopped container via /container/stop:', sandboxId);
-        return Response.json({ ok: true, sandboxId });
+        try {
+          await getSandbox(env.Sandbox, sandboxId).stop();
+          console.log('[monolith] Stopped container via /container/stop:', sandboxId);
+        } catch (stopErr) {
+          const msg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+          if (/not found|already stopped|no container|does not exist|not running/i.test(msg)) {
+            console.log('[monolith] /container/stop benign (container already stopped or never started):', sandboxId, 'request_id:', stopBody.request_id);
+            return Response.json({ ok: true, note: 'container already stopped or never started' });
+          }
+          throw stopErr;
+        }
+        return Response.json({ ok: true });
       }
 
       // Parse request body

--- a/warg/workers/monolith/src/index.ts
+++ b/warg/workers/monolith/src/index.ts
@@ -116,6 +116,7 @@ function validateBaseUrl(url: string): string {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new MonolithServiceError('base_url must be http or https', 'INVALID_INPUT_URL', 400, false);
   }
+  // eslint-disable-next-line no-control-regex -- rejecting control chars in URLs is the point
   if (/[\u0000-\u001F\u007F]/.test(url)) {
     throw new MonolithServiceError(
       'base_url contains invalid characters',

--- a/warg/workers/monolith/src/monolith-command.ts
+++ b/warg/workers/monolith/src/monolith-command.ts
@@ -22,7 +22,7 @@ export const SANDBOX_OUTPUT_PATH = '/workspace/out.html';
  * Quote an argument for POSIX shell execution.
  */
 export function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 /**

--- a/warg/workers/monolith/src/monolith-lifecycle.test.ts
+++ b/warg/workers/monolith/src/monolith-lifecycle.test.ts
@@ -143,7 +143,7 @@ describe('runMonolithInSandbox container lifecycle', () => {
     expect(result.artifact.bytes).toBe(1234);
     expect(sandbox.stop).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      '[monolith] stop() failed (non-fatal):',
+      expect.stringMatching(/\[monolith\] stop\(\) failed for req-stop-fail \(sandbox: req-stop-fail\) — non-fatal/),
       expect.any(Error)
     );
     warnSpy.mockRestore();
@@ -165,5 +165,27 @@ describe('runMonolithInSandbox container lifecycle', () => {
 
     expect(sandbox.stop).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
+  });
+
+  it('returns success and stops the container once when primary exec fails but curl fallback succeeds', async () => {
+    // Queue: [primary fail, curl ok, monolith-file ok, upload ok]
+    const sandbox = fakeSandbox([
+      execFail('monolith: presigned URL fetch error'),
+      execOk(),                       // curl download succeeds
+      execOk(),                       // monolith file-path run succeeds
+      execOk(UPLOAD_OK_STDOUT)        // upload + hash succeeds
+    ]);
+
+    const result = await runMonolithInSandbox(
+      createEnv(),
+      'req-curl-fallback',
+      'archives/req-curl-fallback/raw/rendered.html',
+      'https://example.com'
+    );
+
+    expect(result.artifact.kind).toBe('monolith.html');
+    expect(result.artifact.bytes).toBe(1234);
+    expect(result.artifact.sha256).toBe('a'.repeat(64));
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/warg/workers/monolith/src/monolith-lifecycle.test.ts
+++ b/warg/workers/monolith/src/monolith-lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSandbox } from '@cloudflare/sandbox';
+import { runMonolithInSandbox } from './index.js';
+
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: vi.fn(),
+  Sandbox: class {}
+}));
+
+vi.mock('./r2-presign.js', () => ({
+  presignR2GetUrl: vi.fn(async () => 'https://r2.example/presigned-get'),
+  presignR2PutUrl: vi.fn(async () => 'https://r2.example/presigned-put')
+}));
+
+const getSandboxMock = vi.mocked(getSandbox);
+
+interface ExecResult {
+  success: boolean;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function execOk(stdout = ''): ExecResult {
+  return { success: true, exitCode: 0, stdout, stderr: '' };
+}
+
+function execFail(stderr: string): ExecResult {
+  return { success: false, exitCode: 1, stdout: '', stderr };
+}
+
+const UPLOAD_OK_STDOUT = `SHA256=${'a'.repeat(64)}\nBYTES=1234\n`;
+
+/**
+ * Fake sandbox whose exec() pops results off a queue, in call order:
+ * [monolith run, (curl fallback, monolith file run,) upload].
+ */
+function fakeSandbox(execResults: ExecResult[]) {
+  const sandbox = {
+    exec: vi.fn(async () => {
+      const next = execResults.shift();
+      if (!next) throw new Error('unexpected exec call');
+      return next;
+    }),
+    stop: vi.fn(async () => {})
+  };
+  getSandboxMock.mockReturnValue(sandbox as unknown as ReturnType<typeof getSandbox>);
+  return sandbox;
+}
+
+function createEnv(): Env {
+  return {
+    INTERNAL_API_KEY: 'test-key',
+    R2_BUCKET_NAME: 'warg-archives',
+    R2_ACCOUNT_ID: 'acct',
+    R2_ACCESS_KEY_ID: 'key-id',
+    R2_SECRET_ACCESS_KEY: 'key-secret',
+    Sandbox: {},
+    ARCHIVE_BUCKET: {}
+  } as unknown as Env;
+}
+
+describe('runMonolithInSandbox container lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops the container once on the success path', async () => {
+    const sandbox = fakeSandbox([execOk(), execOk(UPLOAD_OK_STDOUT)]);
+
+    const result = await runMonolithInSandbox(
+      createEnv(),
+      'req-success',
+      'archives/req-success/raw/rendered.html',
+      'https://example.com'
+    );
+
+    expect(result.artifact.kind).toBe('monolith.html');
+    expect(result.artifact.bytes).toBe(1234);
+    expect(result.artifact.sha256).toBe('a'.repeat(64));
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys the sandbox off the request id (no warm pool)', async () => {
+    fakeSandbox([execOk(), execOk(UPLOAD_OK_STDOUT)]);
+
+    const result = await runMonolithInSandbox(
+      createEnv(),
+      'Req-Keyed-123',
+      'archives/req/raw/rendered.html',
+      'https://example.com'
+    );
+
+    expect(result.sandboxId).toBe('req-keyed-123');
+    expect(getSandboxMock).toHaveBeenCalledWith(expect.anything(), 'req-keyed-123');
+  });
+
+  it('stops the container once when execution fails (primary + curl fallback)', async () => {
+    const sandbox = fakeSandbox([
+      execFail('monolith blew up'),
+      execFail('curl failed too')
+    ]);
+
+    await expect(
+      runMonolithInSandbox(
+        createEnv(),
+        'req-exec-fail',
+        'archives/req-exec-fail/raw/rendered.html',
+        'https://example.com'
+      )
+    ).rejects.toThrow(/Sandbox execution failed/);
+
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the container once when the upload fails', async () => {
+    const sandbox = fakeSandbox([execOk(), execFail('upload broke')]);
+
+    await expect(
+      runMonolithInSandbox(
+        createEnv(),
+        'req-upload-fail',
+        'archives/req-upload-fail/raw/rendered.html',
+        'https://example.com'
+      )
+    ).rejects.toThrow();
+
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mask the job result when stop() itself fails', async () => {
+    const sandbox = fakeSandbox([execOk(), execOk(UPLOAD_OK_STDOUT)]);
+    sandbox.stop.mockRejectedValueOnce(new Error('stop exploded'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await runMonolithInSandbox(
+      createEnv(),
+      'req-stop-fail',
+      'archives/req-stop-fail/raw/rendered.html',
+      'https://example.com'
+    );
+
+    expect(result.artifact.bytes).toBe(1234);
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[monolith] stop() failed (non-fatal):',
+      expect.any(Error)
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not mask the original error when both the job and stop() fail', async () => {
+    const sandbox = fakeSandbox([execFail('original failure'), execFail('curl failed')]);
+    sandbox.stop.mockRejectedValueOnce(new Error('stop exploded'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      runMonolithInSandbox(
+        createEnv(),
+        'req-double-fail',
+        'archives/req-double-fail/raw/rendered.html',
+        'https://example.com'
+      )
+    ).rejects.toThrow(/original failure/);
+
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/warg/workers/monolith/src/types.ts
+++ b/warg/workers/monolith/src/types.ts
@@ -7,7 +7,6 @@ export interface MonolithRequest {
   request_id: string;
   rendered_html_key: string; // R2 key to fetch HTML from
   base_url: string; // Base URL for resolving relative links
-  sandbox_id?: string; // Warm-pool sandbox to run in (e.g. `monolith-pool-2`); falls back to a per-request id
 }
 
 /**

--- a/warg/workers/monolith/wrangler.jsonc
+++ b/warg/workers/monolith/wrangler.jsonc
@@ -22,7 +22,7 @@
       "instance_type": "standard-1",
       "max_instances": 5
       // Lifecycle: containers are stopped per job (stop() in a finally block in
-      // src/index.ts) with a 30s sleepAfter backstop set on the Sandbox subclass
+      // src/index.ts) with a 5m sleepAfter backstop set on the Sandbox subclass
       // there — wrangler's containers config has no sleep_after key.
     }
   ],

--- a/warg/workers/monolith/wrangler.jsonc
+++ b/warg/workers/monolith/wrangler.jsonc
@@ -21,6 +21,9 @@
       // monolith base64-inlines heavy pages. ("standard" is the deprecated alias.)
       "instance_type": "standard-1",
       "max_instances": 5
+      // Lifecycle: containers are stopped per job (stop() in a finally block in
+      // src/index.ts) with a 30s sleepAfter backstop set on the Sandbox subclass
+      // there — wrangler's containers config has no sleep_after key.
     }
   ],
   "durable_objects": {

--- a/warg/workers/readability/package.json
+++ b/warg/workers/readability/package.json
@@ -16,6 +16,6 @@
     "linkedom": "^0.18.9"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/renderer/src/index.ts
+++ b/warg/workers/renderer/src/index.ts
@@ -4,8 +4,7 @@ import type {
   RenderRequest,
   RenderSuccessResponse,
   RenderRateLimitedResponse,
-  RendererOptions,
-  BrowserQuotaKind
+  RendererOptions
 } from './types.js';
 
 const BR_BASE = 'https://api.cloudflare.com/client/v4/accounts';

--- a/warg/workers/singlefile/src/index.ts
+++ b/warg/workers/singlefile/src/index.ts
@@ -293,10 +293,10 @@ export default {
 
         // Step 4: Verify + Capture
         const singlefileAvailable = await page.evaluate(() => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+           
           const runtime = globalThis as unknown as { singlefile?: { getPageData?: unknown } };
           return typeof runtime.singlefile !== 'undefined' &&
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+             
             typeof runtime.singlefile?.getPageData === 'function';
         });
 
@@ -314,7 +314,7 @@ export default {
         try {
           result = await Promise.race([
             page.evaluate(async (opts: SinglefileNativeOptions) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+               
               const runtime = globalThis as unknown as { singlefile: { getPageData: (options: SinglefileNativeOptions) => Promise<unknown> } };
               const sf = runtime.singlefile;
               return await sf.getPageData(opts);

--- a/warg/workers/workflow/README.md
+++ b/warg/workers/workflow/README.md
@@ -1,0 +1,30 @@
+# workflow
+
+Cloudflare Workflows orchestrator for the URL-to-archive pipeline. Internal
+worker (`X-Internal-API-Key` required on all HTTP routes).
+
+Steps in order: `render → derive → manifest → persist → done`
+
+Each quota-gated step (render, monolith, singlefile) calls into
+`BrowserQuotaDO` to acquire a container lease before starting work.
+
+## Quota-acquire config
+
+Quota acquisition is a bounded retry loop in `src/quota-acquire.ts`:
+
+| Setting | Value | Notes |
+|---|---|---|
+| `MAX_QUOTA_ATTEMPTS` | 20 | maximum acquire attempts before giving up |
+| `QUOTA_SLEEP_DURATION` | `'30 seconds'` | `step.sleep` between denied attempts |
+| Worst-case wait | 10 minutes | 20 × 30s, matching the orphan cron-sweep window |
+| Inner step retries | 2 | transient DO errors only; quota denial is a return value, not an exception |
+
+Each `step.sleep` suspends the workflow and bills zero CPU. A quota grant
+failure after all attempts throws a plain `Error` — the request must be
+manually resubmitted; there is no automatic retry at the workflow level.
+
+## Tests
+
+```bash
+pnpm --filter @warg/workflow test
+```

--- a/warg/workers/workflow/package.json
+++ b/warg/workers/workflow/package.json
@@ -14,6 +14,6 @@
     "@warg/shared": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^2.1.8"
+    "vitest": "^4.1.8"
   }
 }

--- a/warg/workers/workflow/src/BrowserQuotaDO.ts
+++ b/warg/workers/workflow/src/BrowserQuotaDO.ts
@@ -165,6 +165,30 @@ export class BrowserQuotaDO extends DurableObject<Env> {
   }
 
   /**
+   * List currently-held sandbox_exec leases. Read-only — no cleanup, no
+   * persistence. Backs the gateway's orphan-container sweep, which stops the
+   * container behind any lease that outlived the TTL (its workflow likely
+   * crashed before release()).
+   */
+  async listSandboxLeases(): Promise<
+    Array<{ leaseId: string; requestId: string; acquiredAt: number }>
+  > {
+    await this.loadState();
+
+    const leases: Array<{ leaseId: string; requestId: string; acquiredAt: number }> = [];
+    for (const lease of this.activeLeases!.values()) {
+      if (lease.kind === 'sandbox_exec') {
+        leases.push({
+          leaseId: lease.leaseId,
+          requestId: lease.requestId,
+          acquiredAt: lease.acquiredAt
+        });
+      }
+    }
+    return leases;
+  }
+
+  /**
    * Release a quota lease.
    * RPC method - called directly from workflow.
    * Idempotent - safe to call multiple times with same leaseId.

--- a/warg/workers/workflow/src/BrowserQuotaDO.ts
+++ b/warg/workers/workflow/src/BrowserQuotaDO.ts
@@ -1,7 +1,6 @@
 import { DurableObject } from 'cloudflare:workers';
 import {
   evaluateAcquire,
-  lowestFreeSlot,
   type LeaseKind,
   type QuotaLimits,
   type TokenBucket
@@ -15,8 +14,6 @@ interface Lease {
   requestId: string;
   kind: LeaseKind;
   acquiredAt: number;
-  /** Warm-pool slot index, assigned only to `sandbox_exec` leases. */
-  slot?: number;
 }
 
 /**
@@ -26,8 +23,6 @@ export interface AcquireResult {
   granted: boolean;
   leaseId?: string;
   retryAfterMs?: number;
-  /** Warm-pool slot index for `sandbox_exec` grants (stable container reuse). */
-  slot?: number;
 }
 
 interface StoredState {
@@ -140,28 +135,12 @@ export class BrowserQuotaDO extends DurableObject<Env> {
     }
 
     const leaseId = crypto.randomUUID();
-    // sandbox_exec leases get a stable warm-pool slot so the monolith worker
-    // reuses a small fixed set of containers instead of cold-starting a unique
-    // sandbox per request (the cold-start churn that drives Sandbox exec-500s).
-    const slot = kind === 'sandbox_exec' ? this.assignSandboxSlot() : undefined;
-    this.activeLeases!.set(leaseId, { leaseId, requestId, kind, acquiredAt: now, slot });
+    this.activeLeases!.set(leaseId, { leaseId, requestId, kind, acquiredAt: now });
 
     await this.saveState();
     this.scheduleCleanup();
 
-    return slot === undefined ? { granted: true, leaseId } : { granted: true, leaseId, slot };
-  }
-
-  /**
-   * Pick the lowest free warm-pool slot in [0, MAX_SANDBOX_CONCURRENT).
-   * The concurrency check already guaranteed a slot is free before this runs.
-   */
-  private assignSandboxSlot(): number {
-    const used: number[] = [];
-    for (const lease of this.activeLeases!.values()) {
-      if (lease.kind === 'sandbox_exec' && lease.slot !== undefined) used.push(lease.slot);
-    }
-    return lowestFreeSlot(used);
+    return { granted: true, leaseId };
   }
 
   /**
@@ -169,6 +148,11 @@ export class BrowserQuotaDO extends DurableObject<Env> {
    * persistence. Backs the gateway's orphan-container sweep, which stops the
    * container behind any lease that outlived the TTL (its workflow likely
    * crashed before release()).
+   *
+   * The returned list is a point-in-time snapshot as of this RPC. Because the
+   * DO executes single-threaded the snapshot is internally consistent, but the
+   * gateway sweep must treat it as a best-effort hint: leases may be acquired
+   * or released between this call and any action the sweep takes.
    */
   async listSandboxLeases(): Promise<
     Array<{ leaseId: string; requestId: string; acquiredAt: number }>

--- a/warg/workers/workflow/src/index.ts
+++ b/warg/workers/workflow/src/index.ts
@@ -1358,6 +1358,7 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
   }
 
   private toMonolithBaseUrl(rawUrl: string): string {
+    // eslint-disable-next-line no-control-regex -- stripping control chars from URLs is the point
     const sanitized = rawUrl.replace(/[\u0000-\u001F\u007F]/g, '').trim();
     try {
       const parsed = new URL(sanitized);

--- a/warg/workers/workflow/src/index.ts
+++ b/warg/workers/workflow/src/index.ts
@@ -12,7 +12,7 @@ import type {
   WorkflowCheckpoint,
   WorkflowStep as WorkflowStepType,
 } from '@warg/shared';
-import { getR2Key, getStepManifestKey } from '@warg/shared';
+import { getR2Key, getStepManifestKey, timingSafeEqual } from '@warg/shared';
 import { BrowserQuotaDO } from './BrowserQuotaDO.js';
 import type {
   WorkflowParams,
@@ -774,8 +774,7 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     step: WorkflowStep,
     requestId: string,
     renderedHtmlKey: string,
-    monolithBaseUrl: string,
-    sandboxId: string | undefined
+    monolithBaseUrl: string
   ): Promise<Awaited<ReturnType<typeof callMonolith>>> {
     // Workstream B2: monolith either produces in well under 2 min or it won't;
     // 3×5-min retries were the main driver of the derive-latency tail. Cap at
@@ -793,8 +792,7 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
             return await callMonolith(this.env, {
               request_id: requestId,
               rendered_html_key: renderedHtmlKey,
-              base_url: monolithBaseUrl,
-              sandbox_id: sandboxId
+              base_url: monolithBaseUrl
             });
           }
         );
@@ -830,7 +828,7 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     renderedHtmlKey: string,
     monolithBaseUrl: string
   ): Promise<Awaited<ReturnType<typeof callMonolith>>> {
-    const { leaseId, slot } = await step.do(
+    const { leaseId } = await step.do(
       'acquire-monolith-quota',
       {
         retries: { limit: 20, delay: '3 seconds', backoff: 'linear' },
@@ -844,24 +842,19 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
         if (!result.granted) {
           throw new Error(`Sandbox quota unavailable, retry after ${result.retryAfterMs}ms`);
         }
-        return { leaseId: result.leaseId!, slot: result.slot };
+        return { leaseId: result.leaseId! };
       }
     );
 
-    // Pin this job to a stable warm-pool container so the monolith worker reuses
-    // a fixed set of sandboxes instead of cold-starting a unique one per request.
-    // For instances whose acquire step was checkpointed before warm-pool rollout
-    // (cached result has no slot), send no id and let monolith use a per-request
-    // sandbox — never a shared `monolith-pool-undefined`.
-    const sandboxId = typeof slot === 'number' ? `monolith-pool-${slot}` : undefined;
-
+    // No warm pool: the monolith worker keys the sandbox off the request id and
+    // stops the container after the job, trading per-job cold starts for not
+    // billing idle DO duration between jobs.
     try {
       return await this.callMonolithWithRetry(
         step,
         requestId,
         renderedHtmlKey,
-        monolithBaseUrl,
-        sandboxId
+        monolithBaseUrl
       );
     } finally {
       await step.do('release-monolith-quota', async () => {
@@ -1441,6 +1434,27 @@ export default {
         }
       } catch (err) {
         console.error('[workflow] Error starting workflow:', err);
+        const errMsg = err instanceof Error ? err.message : String(err);
+        return Response.json({ error: 'Internal error', message: errMsg }, { status: 500 });
+      }
+    }
+
+    // GET /browser-quota/sandbox-leases - active sandbox_exec leases, read-only.
+    // Consumed by the gateway's orphan-container sweep. Unlike /start and
+    // /status (service-binding-only callers), this is guarded by the internal
+    // API key since it exposes quota state.
+    if (request.method === 'GET' && url.pathname === '/browser-quota/sandbox-leases') {
+      const apiKey = request.headers.get('X-Internal-API-Key');
+      if (!apiKey || !timingSafeEqual(apiKey, env.INTERNAL_API_KEY)) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      try {
+        const stub = env.BROWSER_QUOTA.get(env.BROWSER_QUOTA.idFromName('global'));
+        const leases = await stub.listSandboxLeases();
+        return Response.json({ leases });
+      } catch (err) {
+        console.error('[workflow] Error listing sandbox leases:', err);
         const errMsg = err instanceof Error ? err.message : String(err);
         return Response.json({ error: 'Internal error', message: errMsg }, { status: 500 });
       }

--- a/warg/workers/workflow/src/index.ts
+++ b/warg/workers/workflow/src/index.ts
@@ -14,6 +14,7 @@ import type {
 } from '@warg/shared';
 import { getR2Key, getStepManifestKey, timingSafeEqual } from '@warg/shared';
 import { BrowserQuotaDO } from './BrowserQuotaDO.js';
+import { acquireQuotaWithSleep } from './quota-acquire.js';
 import type {
   WorkflowParams,
   ArchiveOptionsExtended,
@@ -30,12 +31,15 @@ import {
 } from './services.js';
 import {
   logEvent,
+  logEvents,
   logStepStarted,
   logStepCompletedWithDuration,
   logStepFailed,
   logArtifactWritten,
   logRequestDone,
   logRequestFailed,
+  artifactWrittenEvent,
+  stepCompletedEvent,
   updateManifestKey
 } from './logging.js';
 import { runMockPipeline } from './mock.js';
@@ -828,23 +832,16 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     renderedHtmlKey: string,
     monolithBaseUrl: string
   ): Promise<Awaited<ReturnType<typeof callMonolith>>> {
-    const { leaseId } = await step.do(
-      'acquire-monolith-quota',
-      {
-        retries: { limit: 20, delay: '3 seconds', backoff: 'linear' },
-        timeout: '10 minutes'
-      },
-      async () => {
-        const stub = this.env.BROWSER_QUOTA.get(
-          this.env.BROWSER_QUOTA.idFromName('global')
-        );
-        const result = await stub.acquire('sandbox_exec', requestId);
-        if (!result.granted) {
-          throw new Error(`Sandbox quota unavailable, retry after ${result.retryAfterMs}ms`);
-        }
-        return { leaseId: result.leaseId! };
+    const { leaseId } = await acquireQuotaWithSleep(step, 'monolith', async () => {
+      const stub = this.env.BROWSER_QUOTA.get(
+        this.env.BROWSER_QUOTA.idFromName('global')
+      );
+      const result = await stub.acquire('sandbox_exec', requestId);
+      if (!result.granted) {
+        return { granted: false, retryAfterMs: result.retryAfterMs };
       }
-    );
+      return { granted: true, leaseId: result.leaseId! };
+    });
 
     // No warm pool: the monolith worker keys the sandbox off the request id and
     // stops the container after the job, trading per-job cold starts for not
@@ -940,24 +937,17 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     url: string,
     options: ArchiveOptionsExtended
   ): Promise<RenderStepResult> {
-    // Acquire quota (with retry)
-    const { leaseId } = await step.do(
-      'acquire-render-quota',
-      {
-        retries: { limit: 20, delay: '3 seconds', backoff: 'linear' },
-        timeout: '10 minutes'
-      },
-      async () => {
-        const stub = this.env.BROWSER_QUOTA.get(
-          this.env.BROWSER_QUOTA.idFromName('global')
-        );
-        const result = await stub.acquire('bindings_launch', requestId);
-        if (!result.granted) {
-          throw new Error(`Quota unavailable, retry after ${result.retryAfterMs}ms`);
-        }
-        return { leaseId: result.leaseId! };
+    // Acquire quota (sleep-reschedule between denied attempts)
+    const { leaseId } = await acquireQuotaWithSleep(step, 'render', async () => {
+      const stub = this.env.BROWSER_QUOTA.get(
+        this.env.BROWSER_QUOTA.idFromName('global')
+      );
+      const result = await stub.acquire('bindings_launch', requestId);
+      if (!result.granted) {
+        return { granted: false, retryAfterMs: result.retryAfterMs };
       }
-    );
+      return { granted: true, leaseId: result.leaseId! };
+    });
 
     try {
       // Log step start + capture timing
@@ -988,28 +978,29 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
 
       // Log artifacts + duration + enriched meta
       await step.do('log-render-artifacts', async () => {
-        for (const artifact of renderResult.artifacts) {
-          await logArtifactWritten(
-            this.env,
-            requestId,
+        const events = renderResult.artifacts.map((artifact) =>
+          artifactWrittenEvent(
             artifact.kind,
             artifact.r2Key,
             artifact.bytes,
             artifact.contentType,
             artifact.sha256
-          );
-        }
-        await logStepCompletedWithDuration(this.env, requestId, 'render', renderStartedAt, {
-          artifactCount: renderResult.artifacts.length,
-          ...(renderOutcome.fallbackUsed
-            ? {
-                fallbackUsed: true,
-                fallbackReason: renderOutcome.fallbackReason,
-                fallbackProvider: renderResult.meta?.provider ?? 'hyperbrowser'
-              }
-            : {}),
-          ...(renderResult.meta ? { meta: renderResult.meta } : {})
-        });
+          )
+        );
+        events.push(
+          stepCompletedEvent('render', renderStartedAt, {
+            artifactCount: renderResult.artifacts.length,
+            ...(renderOutcome.fallbackUsed
+              ? {
+                  fallbackUsed: true,
+                  fallbackReason: renderOutcome.fallbackReason,
+                  fallbackProvider: renderResult.meta?.provider ?? 'hyperbrowser'
+                }
+              : {}),
+            ...(renderResult.meta ? { meta: renderResult.meta } : {})
+          })
+        );
+        await logEvents(this.env, requestId, events);
       });
 
       // Find the rendered HTML key
@@ -1051,24 +1042,17 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     url: string,
     optionsR2Key: string
   ): Promise<ArtifactMeta> {
-    // Acquire quota (with retry)
-    const { leaseId } = await step.do(
-      'acquire-singlefile-quota',
-      {
-        retries: { limit: 20, delay: '3 seconds', backoff: 'linear' },
-        timeout: '10 minutes'
-      },
-      async () => {
-        const stub = this.env.BROWSER_QUOTA.get(
-          this.env.BROWSER_QUOTA.idFromName('global')
-        );
-        const result = await stub.acquire('bindings_launch', requestId);
-        if (!result.granted) {
-          throw new Error(`Quota unavailable, retry after ${result.retryAfterMs}ms`);
-        }
-        return { leaseId: result.leaseId! };
+    // Acquire quota (sleep-reschedule between denied attempts)
+    const { leaseId } = await acquireQuotaWithSleep(step, 'singlefile', async () => {
+      const stub = this.env.BROWSER_QUOTA.get(
+        this.env.BROWSER_QUOTA.idFromName('global')
+      );
+      const result = await stub.acquire('bindings_launch', requestId);
+      if (!result.granted) {
+        return { granted: false, retryAfterMs: result.retryAfterMs };
       }
-    );
+      return { granted: true, leaseId: result.leaseId! };
+    });
 
     try {
       // Log step start + capture timing

--- a/warg/workers/workflow/src/index.ts
+++ b/warg/workers/workflow/src/index.ts
@@ -832,16 +832,23 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     renderedHtmlKey: string,
     monolithBaseUrl: string
   ): Promise<Awaited<ReturnType<typeof callMonolith>>> {
-    const { leaseId } = await acquireQuotaWithSleep(step, 'monolith', async () => {
-      const stub = this.env.BROWSER_QUOTA.get(
-        this.env.BROWSER_QUOTA.idFromName('global')
-      );
-      const result = await stub.acquire('sandbox_exec', requestId);
-      if (!result.granted) {
-        return { granted: false, retryAfterMs: result.retryAfterMs };
-      }
-      return { granted: true, leaseId: result.leaseId! };
-    });
+    const { leaseId } = await acquireQuotaWithSleep(
+      step,
+      'monolith',
+      async () => {
+        const stub = this.env.BROWSER_QUOTA.get(
+          this.env.BROWSER_QUOTA.idFromName('global')
+        );
+        const result = await stub.acquire('sandbox_exec', requestId);
+        if (!result.granted) {
+          return { granted: false, retryAfterMs: result.retryAfterMs };
+        }
+        return { granted: true, leaseId: result.leaseId! };
+      },
+      undefined,
+      undefined,
+      (m) => new NonRetryableError(m)
+    );
 
     // No warm pool: the monolith worker keys the sandbox off the request id and
     // stops the container after the job, trading per-job cold starts for not
@@ -938,16 +945,23 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     options: ArchiveOptionsExtended
   ): Promise<RenderStepResult> {
     // Acquire quota (sleep-reschedule between denied attempts)
-    const { leaseId } = await acquireQuotaWithSleep(step, 'render', async () => {
-      const stub = this.env.BROWSER_QUOTA.get(
-        this.env.BROWSER_QUOTA.idFromName('global')
-      );
-      const result = await stub.acquire('bindings_launch', requestId);
-      if (!result.granted) {
-        return { granted: false, retryAfterMs: result.retryAfterMs };
-      }
-      return { granted: true, leaseId: result.leaseId! };
-    });
+    const { leaseId } = await acquireQuotaWithSleep(
+      step,
+      'render',
+      async () => {
+        const stub = this.env.BROWSER_QUOTA.get(
+          this.env.BROWSER_QUOTA.idFromName('global')
+        );
+        const result = await stub.acquire('bindings_launch', requestId);
+        if (!result.granted) {
+          return { granted: false, retryAfterMs: result.retryAfterMs };
+        }
+        return { granted: true, leaseId: result.leaseId! };
+      },
+      undefined,
+      undefined,
+      (m) => new NonRetryableError(m)
+    );
 
     try {
       // Log step start + capture timing
@@ -1043,16 +1057,23 @@ export class ArchiveWorkflow extends WorkflowEntrypoint<Env, WorkflowParams> {
     optionsR2Key: string
   ): Promise<ArtifactMeta> {
     // Acquire quota (sleep-reschedule between denied attempts)
-    const { leaseId } = await acquireQuotaWithSleep(step, 'singlefile', async () => {
-      const stub = this.env.BROWSER_QUOTA.get(
-        this.env.BROWSER_QUOTA.idFromName('global')
-      );
-      const result = await stub.acquire('bindings_launch', requestId);
-      if (!result.granted) {
-        return { granted: false, retryAfterMs: result.retryAfterMs };
-      }
-      return { granted: true, leaseId: result.leaseId! };
-    });
+    const { leaseId } = await acquireQuotaWithSleep(
+      step,
+      'singlefile',
+      async () => {
+        const stub = this.env.BROWSER_QUOTA.get(
+          this.env.BROWSER_QUOTA.idFromName('global')
+        );
+        const result = await stub.acquire('bindings_launch', requestId);
+        if (!result.granted) {
+          return { granted: false, retryAfterMs: result.retryAfterMs };
+        }
+        return { granted: true, leaseId: result.leaseId! };
+      },
+      undefined,
+      undefined,
+      (m) => new NonRetryableError(m)
+    );
 
     try {
       // Log step start + capture timing

--- a/warg/workers/workflow/src/logging.ts
+++ b/warg/workers/workflow/src/logging.ts
@@ -110,7 +110,7 @@ export function classifyError(stepName: string, errorMsg: string): ClassifiedErr
 
   if (
     msg.includes('execution context was destroyed') ||
-    msg.includes('code\":6000') ||
+    msg.includes('code":6000') ||
     msg.includes('context destroyed')
   ) {
     return {

--- a/warg/workers/workflow/src/logging.ts
+++ b/warg/workers/workflow/src/logging.ts
@@ -199,7 +199,8 @@ async function loggerPost(env: Env, path: string, body: unknown, label: string):
         'Content-Type': 'application/json',
         'X-Internal-API-Key': env.INTERNAL_API_KEY
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!response.ok) {

--- a/warg/workers/workflow/src/logging.ts
+++ b/warg/workers/workflow/src/logging.ts
@@ -1,4 +1,4 @@
-import type { EventType, LogLevel } from '@warg/shared';
+import type { EventType, LogEvent, LogLevel } from '@warg/shared';
 import { createEvent } from '@warg/shared';
 import type { RequestErrorCode, UserActionHint } from '@warg/shared';
 
@@ -219,6 +219,38 @@ export async function logEvent(
 }
 
 /**
+ * Append a batch of events in one logger round-trip (atomic on the logger
+ * side). Use inside multi-event step callbacks; terminal events
+ * (request.done / request.failed) must stay on per-event logEvent calls so
+ * SSE consumers see them immediately.
+ */
+export async function logEvents(
+  env: Env,
+  requestId: string,
+  events: LogEvent[]
+): Promise<void> {
+  if (events.length === 0) return;
+
+  try {
+    const response = await env.LOGGER.fetch('https://logger/events/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Internal-API-Key': env.INTERNAL_API_KEY
+      },
+      body: JSON.stringify({ requestId, events })
+    });
+
+    if (!response.ok) {
+      console.error(`[workflow] Failed to log event batch: ${await response.text()}`);
+    }
+  } catch (err) {
+    // Log to console but don't throw - logging should not block workflow
+    console.error('[workflow] Error logging event batch:', err);
+  }
+}
+
+/**
  * Log a step started event.
  */
 export function logStepStarted(
@@ -267,6 +299,23 @@ export function logStepCompletedWithDuration(
 }
 
 /**
+ * Build a step.completed event with duration tracking for batched logging.
+ * Same payload as logStepCompletedWithDuration, returned instead of sent.
+ */
+export function stepCompletedEvent(
+  stepName: string,
+  startedAt: number,
+  data?: Record<string, unknown>
+): LogEvent {
+  const durationMs = Date.now() - startedAt;
+  return createEvent('workflow', 'step.completed', 'info', `Step completed: ${stepName}`, {
+    step: stepName,
+    ...data,
+    duration_ms: durationMs
+  });
+}
+
+/**
  * Log a step failed event.
  * Accepts string or Error. If Error, includes truncated stack trace.
  */
@@ -311,6 +360,26 @@ export function logArtifactWritten(
   sha256: string
 ): Promise<void> {
   return logEvent(env, requestId, 'artifact.written', `Artifact written: ${kind}`, {
+    kind,
+    r2Key,
+    bytes,
+    contentType,
+    sha256
+  });
+}
+
+/**
+ * Build an artifact.written event for batched logging.
+ * Same payload as logArtifactWritten, returned instead of sent.
+ */
+export function artifactWrittenEvent(
+  kind: string,
+  r2Key: string,
+  bytes: number,
+  contentType: string,
+  sha256: string
+): LogEvent {
+  return createEvent('workflow', 'artifact.written', 'info', `Artifact written: ${kind}`, {
     kind,
     r2Key,
     bytes,

--- a/warg/workers/workflow/src/logging.ts
+++ b/warg/workers/workflow/src/logging.ts
@@ -187,9 +187,34 @@ export function classifyError(stepName: string, errorMsg: string): ClassifiedErr
 }
 
 /**
+ * Module-private helper: POST a JSON body to the logger service binding.
+ * Never throws — logging must not block workflow execution.
+ * @param label  Short description used in failure log messages (e.g. "event [step.started] for req123" or "event batch for req123 (4 events)")
+ */
+async function loggerPost(env: Env, path: string, body: unknown, label: string): Promise<void> {
+  try {
+    const response = await env.LOGGER.fetch(`https://logger${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Internal-API-Key': env.INTERNAL_API_KEY
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const text = (await response.text()).slice(0, 300);
+      console.error(`[workflow] Failed to log ${label}: ${text}`);
+    }
+  } catch (err) {
+    console.error(`[workflow] Error logging ${label}:`, err);
+  }
+}
+
+/**
  * Log an event to the logger service.
  */
-export async function logEvent(
+export function logEvent(
   env: Env,
   requestId: string,
   type: EventType,
@@ -198,24 +223,7 @@ export async function logEvent(
   level: LogLevel = 'info'
 ): Promise<void> {
   const event = createEvent('workflow', type, level, message, data);
-
-  try {
-    const response = await env.LOGGER.fetch('https://logger/event', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Internal-API-Key': env.INTERNAL_API_KEY
-      },
-      body: JSON.stringify({ requestId, event })
-    });
-
-    if (!response.ok) {
-      console.error(`[workflow] Failed to log event: ${await response.text()}`);
-    }
-  } catch (err) {
-    // Log to console but don't throw - logging should not block workflow
-    console.error('[workflow] Error logging event:', err);
-  }
+  return loggerPost(env, '/event', { requestId, event }, `event [${type}] for ${requestId}`);
 }
 
 /**
@@ -230,24 +238,12 @@ export async function logEvents(
   events: LogEvent[]
 ): Promise<void> {
   if (events.length === 0) return;
-
-  try {
-    const response = await env.LOGGER.fetch('https://logger/events/batch', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Internal-API-Key': env.INTERNAL_API_KEY
-      },
-      body: JSON.stringify({ requestId, events })
-    });
-
-    if (!response.ok) {
-      console.error(`[workflow] Failed to log event batch: ${await response.text()}`);
-    }
-  } catch (err) {
-    // Log to console but don't throw - logging should not block workflow
-    console.error('[workflow] Error logging event batch:', err);
-  }
+  await loggerPost(
+    env,
+    '/events/batch',
+    { requestId, events },
+    `event batch for ${requestId} (${events.length} events)`
+  );
 }
 
 /**

--- a/warg/workers/workflow/src/quota-acquire.test.ts
+++ b/warg/workers/workflow/src/quota-acquire.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  acquireQuotaWithSleep,
+  MAX_QUOTA_ATTEMPTS,
+  QUOTA_SLEEP_DURATION,
+  type QuotaAcquireOutcome,
+  type QuotaStep
+} from './quota-acquire.js';
+
+function makeMockStep(): QuotaStep & {
+  do: ReturnType<typeof vi.fn>;
+  sleep: ReturnType<typeof vi.fn>;
+} {
+  return {
+    do: vi.fn(
+      async (
+        _name: string,
+        _config: unknown,
+        callback: () => Promise<QuotaAcquireOutcome>
+      ) => callback()
+    ),
+    sleep: vi.fn(async () => {})
+  };
+}
+
+function denyTimes(denials: number, leaseId = 'lease-1'): () => Promise<QuotaAcquireOutcome> {
+  let calls = 0;
+  return async () => {
+    calls++;
+    if (calls <= denials) {
+      return { granted: false, retryAfterMs: 3000 };
+    }
+    return { granted: true, leaseId };
+  };
+}
+
+describe('acquireQuotaWithSleep', () => {
+  it('returns the lease immediately when the first attempt is granted', async () => {
+    const step = makeMockStep();
+
+    const result = await acquireQuotaWithSleep(step, 'render', denyTimes(0, 'lease-a'));
+
+    expect(result).toEqual({ leaseId: 'lease-a' });
+    expect(step.do).toHaveBeenCalledTimes(1);
+    expect(step.sleep).not.toHaveBeenCalled();
+  });
+
+  it('sleeps between denied attempts and returns the lease once granted', async () => {
+    const step = makeMockStep();
+
+    const result = await acquireQuotaWithSleep(step, 'render', denyTimes(3, 'lease-b'));
+
+    expect(result).toEqual({ leaseId: 'lease-b' });
+    expect(step.do).toHaveBeenCalledTimes(4);
+    expect(step.sleep).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws a plain Error after exhausting the attempt budget', async () => {
+    const step = makeMockStep();
+
+    await expect(
+      acquireQuotaWithSleep(step, 'monolith', denyTimes(Infinity), 5)
+    ).rejects.toThrow('monolith quota not acquired after 5 attempts');
+
+    expect(step.do).toHaveBeenCalledTimes(5);
+    // No sleep after the final attempt
+    expect(step.sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it('uses deterministic step and sleep names with the attempt counter', async () => {
+    const step = makeMockStep();
+
+    await acquireQuotaWithSleep(step, 'singlefile', denyTimes(2));
+
+    expect(step.do.mock.calls.map((call) => call[0])).toEqual([
+      'acquire-singlefile-quota-attempt-1',
+      'acquire-singlefile-quota-attempt-2',
+      'acquire-singlefile-quota-attempt-3'
+    ]);
+    expect(step.sleep.mock.calls.map((call) => call[0])).toEqual([
+      'wait-for-singlefile-quota-1',
+      'wait-for-singlefile-quota-2'
+    ]);
+    expect(step.sleep.mock.calls.every((call) => call[1] === QUOTA_SLEEP_DURATION)).toBe(true);
+  });
+
+  it('configures inner step retries for transient errors only', async () => {
+    const step = makeMockStep();
+
+    await acquireQuotaWithSleep(step, 'render', denyTimes(0));
+
+    expect(step.do.mock.calls[0]?.[1]).toEqual({
+      retries: { limit: 2, delay: '2 seconds', backoff: 'constant' },
+      timeout: '30 seconds'
+    });
+  });
+
+  it('pins the budget confirmed for the 10-minute cron-sweep window', () => {
+    expect(MAX_QUOTA_ATTEMPTS).toBe(20);
+    expect(QUOTA_SLEEP_DURATION).toBe('30 seconds');
+  });
+});

--- a/warg/workers/workflow/src/quota-acquire.test.ts
+++ b/warg/workers/workflow/src/quota-acquire.test.ts
@@ -67,6 +67,28 @@ describe('acquireQuotaWithSleep', () => {
     expect(step.sleep).toHaveBeenCalledTimes(4);
   });
 
+  it('uses the injected createExhaustionError factory for the exhaustion throw', async () => {
+    const step = makeMockStep();
+
+    class CustomExhaustionError extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = 'CustomExhaustionError';
+      }
+    }
+
+    const factory = vi.fn((msg: string) => new CustomExhaustionError(msg));
+
+    await expect(
+      acquireQuotaWithSleep(step, 'render', denyTimes(Infinity), 3, undefined, factory)
+    ).rejects.toBeInstanceOf(CustomExhaustionError);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith(
+      'render quota not acquired after 3 attempts; resubmit the request to retry'
+    );
+  });
+
   it('uses deterministic step and sleep names with the attempt counter', async () => {
     const step = makeMockStep();
 
@@ -98,5 +120,20 @@ describe('acquireQuotaWithSleep', () => {
   it('pins the budget confirmed for the 10-minute cron-sweep window', () => {
     expect(MAX_QUOTA_ATTEMPTS).toBe(20);
     expect(QUOTA_SLEEP_DURATION).toBe('30 seconds');
+  });
+
+  it('exhausts the DEFAULT budget (20 attempts), reports "20 attempts", and sleeps exactly 19 times', async () => {
+    const step = makeMockStep();
+
+    await expect(
+      acquireQuotaWithSleep(step, 'render', denyTimes(Infinity))
+    ).rejects.toThrow('render quota not acquired after 20 attempts');
+
+    // All 20 attempt slots consumed
+    expect(step.do).toHaveBeenCalledTimes(20);
+    // Sleep called between each denied attempt — 19 times (not after the final one)
+    expect(step.sleep).toHaveBeenCalledTimes(19);
+    // Every sleep uses the canonical duration constant
+    expect(step.sleep.mock.calls.every((call) => call[1] === QUOTA_SLEEP_DURATION)).toBe(true);
   });
 });

--- a/warg/workers/workflow/src/quota-acquire.ts
+++ b/warg/workers/workflow/src/quota-acquire.ts
@@ -1,0 +1,72 @@
+/**
+ * Bounded quota-acquire loop shared by the three quota-gated pipeline steps.
+ *
+ * Each attempt is a small step.do whose retries cover transient DO failures
+ * only — quota denial is a return value, not an exception. Between denied
+ * attempts the workflow suspends via step.sleep, which bills zero CPU and
+ * does not consume the step budget, so contended jobs reschedule instead of
+ * spinning or failing (the old config burned 20 × 3s retries inside one step).
+ *
+ * Kept free of cloudflare imports so the loop is unit-testable in plain Node
+ * (same convention as quota-logic.ts).
+ */
+
+/** Worst-case wait 20 × 30s = 10 minutes, matching the orphan cron-sweep window. */
+export const MAX_QUOTA_ATTEMPTS = 20;
+export const QUOTA_SLEEP_DURATION = '30 seconds';
+
+/** Literal type keeps QuotaStep.sleep assignable from WorkflowStep.sleep. */
+type QuotaSleepDuration = typeof QUOTA_SLEEP_DURATION;
+
+/** Inner retries handle transient DO errors only; denial never throws. */
+const ACQUIRE_STEP_CONFIG = {
+  retries: { limit: 2, delay: '2 seconds', backoff: 'constant' },
+  timeout: '30 seconds'
+} as const;
+
+export type QuotaAcquireOutcome =
+  | { granted: true; leaseId: string }
+  | { granted: false; retryAfterMs?: number };
+
+/**
+ * Structural subset of Cloudflare's WorkflowStep used by the loop.
+ */
+export interface QuotaStep {
+  do(
+    name: string,
+    config: typeof ACQUIRE_STEP_CONFIG,
+    callback: () => Promise<QuotaAcquireOutcome>
+  ): Promise<QuotaAcquireOutcome>;
+  sleep(name: string, duration: QuotaSleepDuration): Promise<void>;
+}
+
+/**
+ * Acquire a quota lease, sleeping between denied attempts. Step and sleep
+ * names embed the attempt counter so they stay deterministic on replay.
+ * Throws a plain Error (retried-by-resubmission, not NonRetryableError)
+ * once the attempt budget is exhausted.
+ */
+export async function acquireQuotaWithSleep(
+  step: QuotaStep,
+  kind: 'monolith' | 'render' | 'singlefile',
+  attemptAcquire: () => Promise<QuotaAcquireOutcome>,
+  maxAttempts: number = MAX_QUOTA_ATTEMPTS,
+  sleepDuration: QuotaSleepDuration = QUOTA_SLEEP_DURATION
+): Promise<{ leaseId: string }> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await step.do(
+      `acquire-${kind}-quota-attempt-${attempt}`,
+      ACQUIRE_STEP_CONFIG,
+      attemptAcquire
+    );
+    if (result.granted) {
+      return { leaseId: result.leaseId };
+    }
+    if (attempt < maxAttempts) {
+      await step.sleep(`wait-for-${kind}-quota-${attempt}`, sleepDuration);
+    }
+  }
+  throw new Error(
+    `${kind} quota not acquired after ${maxAttempts} attempts; resubmit the request to retry`
+  );
+}

--- a/warg/workers/workflow/src/quota-acquire.ts
+++ b/warg/workers/workflow/src/quota-acquire.ts
@@ -9,6 +9,27 @@
  *
  * Kept free of cloudflare imports so the loop is unit-testable in plain Node
  * (same convention as quota-logic.ts).
+ *
+ * ## Worst-case step budget
+ *
+ * Per quota type, the loop consumes at most:
+ *   - 20 step.do "acquire" attempts × up to 3 executions each (1 + retries.limit 2)
+ *     = 60 step.do executions
+ *   - 19 step.sleep calls between denied attempts (step.sleep is zero-billed for
+ *     CPU and does NOT count against the 1 000-step Workflows limit)
+ *
+ * Three quota types run per workflow (render, singlefile, monolith), so the
+ * theoretical ceiling across the whole run is:
+ *   3 × 60 step.do  = 180 extra step slots
+ *   3 × 19 step.sleep = 57 sleeps (free)
+ *
+ * That leaves ~820 of the 1 000-step budget for the rest of the pipeline.
+ * In practice contention is rare and most runs use a single acquire attempt.
+ *
+ * Note: the quota DO's `retryAfterMs` hint is intentionally ignored. The
+ * fixed 30 s sleep cadence was a deliberate PO decision (predictable tail
+ * latency over optimal throughput). Revisit if per-job concurrency reaches
+ * ~10× current volume.
  */
 
 /** Worst-case wait 20 × 30s = 10 minutes, matching the orphan cron-sweep window. */
@@ -43,15 +64,18 @@ export interface QuotaStep {
 /**
  * Acquire a quota lease, sleeping between denied attempts. Step and sleep
  * names embed the attempt counter so they stay deterministic on replay.
- * Throws a plain Error (retried-by-resubmission, not NonRetryableError)
- * once the attempt budget is exhausted.
+ * Throws once the attempt budget is exhausted using the provided factory
+ * (defaults to plain Error; pass `(m) => new NonRetryableError(m)` at call
+ * sites where cloudflare:workflows is available so the engine never replays
+ * the full sleep budget on exhaustion).
  */
 export async function acquireQuotaWithSleep(
   step: QuotaStep,
   kind: 'monolith' | 'render' | 'singlefile',
   attemptAcquire: () => Promise<QuotaAcquireOutcome>,
   maxAttempts: number = MAX_QUOTA_ATTEMPTS,
-  sleepDuration: QuotaSleepDuration = QUOTA_SLEEP_DURATION
+  sleepDuration: QuotaSleepDuration = QUOTA_SLEEP_DURATION,
+  createExhaustionError: (message: string) => Error = (m) => new Error(m)
 ): Promise<{ leaseId: string }> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = await step.do(
@@ -66,7 +90,7 @@ export async function acquireQuotaWithSleep(
       await step.sleep(`wait-for-${kind}-quota-${attempt}`, sleepDuration);
     }
   }
-  throw new Error(
+  throw createExhaustionError(
     `${kind} quota not acquired after ${maxAttempts} attempts; resubmit the request to retry`
   );
 }

--- a/warg/workers/workflow/src/quota-logic.test.ts
+++ b/warg/workers/workflow/src/quota-logic.test.ts
@@ -10,7 +10,7 @@ import {
 
 const LIMITS: QuotaLimits = {
   maxConcurrent: 100,
-  maxSandboxConcurrent: 6,
+  maxSandboxConcurrent: 4,
   launchRatePerSec: 1,
   launchBurst: 3
 };
@@ -122,7 +122,7 @@ describe('evaluateAcquire — bindings_launch', () => {
 
 describe('evaluateAcquire — sandbox_exec', () => {
   it('grants below the sandbox cap and never consumes a launch token', () => {
-    const snap = snapshot({ sandboxActive: 5 });
+    const snap = snapshot({ sandboxActive: 3 });
     const decision = evaluateAcquire('sandbox_exec', snap, LIMITS, 1_000);
     expect(decision.granted).toBe(true);
     expect(decision.bucket.tokens).toBe(LIMITS.launchBurst);

--- a/warg/workers/workflow/src/quota-logic.test.ts
+++ b/warg/workers/workflow/src/quota-logic.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   evaluateAcquire,
-  lowestFreeSlot,
   refillBucket,
   type QuotaLimits,
   type QuotaSnapshot,
@@ -54,24 +53,6 @@ describe('refillBucket', () => {
   it('does not refill on backward clock skew', () => {
     const bucket: TokenBucket = { tokens: 2, lastRefillMs: 2_000 };
     expect(refillBucket(bucket, 1_000, 1, 3)).toBe(bucket);
-  });
-});
-
-describe('lowestFreeSlot', () => {
-  it('returns 0 when nothing is in use', () => {
-    expect(lowestFreeSlot([])).toBe(0);
-  });
-
-  it('fills the lowest gap', () => {
-    expect(lowestFreeSlot([0, 2])).toBe(1);
-  });
-
-  it('appends past a contiguous run', () => {
-    expect(lowestFreeSlot([0, 1, 2])).toBe(3);
-  });
-
-  it('ignores duplicates and order', () => {
-    expect(lowestFreeSlot([2, 0, 2, 0])).toBe(1);
   });
 });
 

--- a/warg/workers/workflow/src/quota-logic.ts
+++ b/warg/workers/workflow/src/quota-logic.ts
@@ -50,17 +50,6 @@ export interface AcquireDecision {
 }
 
 /**
- * Pick the lowest non-negative slot index not present in `usedSlots`.
- * Used to assign a stable warm-pool container to a `sandbox_exec` lease.
- */
-export function lowestFreeSlot(usedSlots: Iterable<number>): number {
-  const used = new Set(usedSlots);
-  let slot = 0;
-  while (used.has(slot)) slot += 1;
-  return slot;
-}
-
-/**
  * Refill the bucket based on elapsed wall-clock time, capped at `burst`.
  * Returns a new bucket; never mutates the input.
  */

--- a/warg/workers/workflow/src/types.ts
+++ b/warg/workers/workflow/src/types.ts
@@ -110,8 +110,6 @@ export interface MonolithParams {
   request_id: string;
   rendered_html_key: string;
   base_url: string;
-  /** Warm-pool sandbox id (e.g. `monolith-pool-2`) for stable container reuse. */
-  sandbox_id?: string;
 }
 
 /**


### PR DESCRIPTION
# Summary

Two independent workstreams, developed and verified together on one branch:

1. **Firestore/GCS access hardening (groundwork)** — closes three over-exposure paths in the Firebase project: the globally-readable `articles` dedup index, world-writable `debug_logs`, and a GCS archive bucket readable by any Google account. This PR contains every piece **except** the final `articles` read-rule flip, which lands in a separate follow-up PR so that existing reads never break (see *Rollout* below).
2. **Durable Objects cost reduction (warg)** — cuts the Cloudflare DO-duration meter (which spiked ~16×, pushing the invoice from ~$5 to ~$18–22/mo) back toward the 400k GB-s/month free tier.

## Problem

- **Access:** any authenticated client — including a one-tap anonymous session or a script reusing the app's bundled `google-services.json` — could enumerate the entire global `articles` index (every URL saved by every user) and read each doc's `gcs_path`; could read/overwrite any session's `debug_logs`; and **any Google account on the internet** could read every archived article directly from `gs://htbase-archives-standard` via the `allAuthenticatedUsers` IAM binding.
- **Cost:** the monolith sandbox container DO (59% of DO requests, wall-time P50 5.1s / P99 180s) ran a warm pool with no `sleepAfter`, and the logger spawned one DO per request — together dominating GB-seconds.

## Solution

### Access hardening (additive-only in this PR)

- **Per-user existence markers** at `users/{uid}/articleMarkers/{key}`: written atomically on backup batches (`itemId` + distinct `resolvedId`); `ArchiveService` gains a guarded retry-once self-heal on `PERMISSION_DENIED` (writes the marker, retries, falls back to a graceful empty state).
- **Ownership-gated marker creation**: clients can only create/update a marker that references an article they own — the rule checks `getAfter()` on the caller's own `users/{uid}/articles/{itemId}`, covering both same-batch backup writes and the self-heal path. Backup batches are capped at 20 articles to fit the rules document-access budget; markers carry an `itemId` field in all producers; self-heal resolves the owning itemId for resolvedId-keyed markers. This closes the marker "self-minting" hole flagged in review.
- **Owner-scoped debug logs**: `debug_logs/{uid}/sessions/{sessionId}` with `isOwner` rules; `FirestoreLogTree` is Hilt-injectable and writes uid-scoped (DEBUG builds only); legacy flat docs denied.
- **Operator scripts (Admin SDK)**: `marker-backfill` (dry-run by default, write-only-missing), `coverage-gate` (exits 1 on any marker gap — the hard precondition before the read-rule flip; rejects partial `--limit` scans), `debug-logs-cleanup` (legacy flat docs only).
- **Scoped archive reads**: new `GET /app/signed-url` on the dashboard API — verifies the Firebase ID token (anonymous/guest tokens are accepted; the per-user ownership check is the gate, and a fresh anonymous uid owns nothing), proves ownership, returns a 15-minute V4 signed URL and never logs it. Android fetches via this lane; the deprecated `GoogleAuthUtil`/`devstorage` path and the storage-consent UI flow are deleted. `storage.rules` now denies direct Firebase-Storage reads of `/archives/**`, making the signed-URL endpoint the sole archive read path.
- **CI**: a rules-test job (emulator suite) now gates the rules deploy; warg CI runs the full workspace test suite.
- **Dependency security sweep**: warg workspace high/critical advisories driven 34 → 0 (vitest 2.x → 4.1.8, `@cloudflare/vitest-pool-workers` 0.8 → 0.16, `firebase-admin` → 13.10.0, `wrangler` → 4.99.0, plus a `pnpm.overrides` backstop for deep transitives).

> **Note:** the `articles` read rule is intentionally still permissive in this PR. The flip ships separately and last.

### Durable Objects cost reduction

- **Container stop-per-job**: warm pool removed; every job stops its sandbox in a `try/finally`; a `sleepAfter = '5m'` backstop covers crash paths; a 10-minute gateway-cron orphan sweep stops leaked containers via lease inspection.
- **Hour-bucketed logger DOs**: logger instances re-keyed to `bucket:YYYYMMDDHH` with a `request_id` column + index; legacy per-request DOs adopted in place; reads resolve the bucket via the D1 index with a transparent legacy fallback — no bulk migration needed.
- **Zero-billed quota waits**: workflow quota spin-loops replaced by `step.sleep` reschedules (20 × 30s budget), which bill no CPU.
- **Batched log events**: `POST /events/batch` writes a whole step's events in one SQLite transaction (byte-equivalent derived output, verified); terminal events stay per-event to preserve SSE latency.
- **Concurrency truth fix**: test limits corrected to the runtime sandbox cap of 4.

## Affected areas

- **Android**: archive fetch path, backup marker writes, debug-log tree, DI modules, detail screen (consent flow removed).
- **Firebase**: `firestore.rules`, `storage.rules`, emulator test suite, README.
- **Warg cloud functions**: dashboard API signed-URL lane; new backfill-scripts package; manifest bumps across functions.
- **Warg workers**: logger, monolith, workflow, gateway (+ new ADR and worker READMEs under `warg/docs` / worker dirs).
- **CI**: `firebase-rules.yml`, `warg-ci.yml`.
- **Shared types**: `MarkerSchema.md`, drift check extended.

## Verification

- Emulator rules suite green: **15/15** on this branch (tightened marker matrix incl. minting-attack denial), **22/22** with the flip applied (full `articles` matrix); ruleset validates clean.
- Android `:app:testDebugUnitTest` **69/69**.
- Backfill scripts **19/19** unit + **8/8** emulator-integration; production **read-only dry-run**: 12,526 articles → 22,799 markers to write; coverage gate correctly reports a gap (exit 1) pre-backfill.
- Dashboard API **22/22** (validation matrix, auth middleware incl. anonymous-rejection, signing core).
- Warg workspace: **311/311** tests across 12 packages, 17-package typecheck clean, lint clean, `wrangler deploy --dry-run` green for all four workers; logger batch-vs-sequential equivalence drive produced byte-identical derived state; 0 flaky reruns.
- `pnpm audit --audit-level=high`: **0** high/critical (9 low/moderate remain, all pre-existing).

## Rollout (two-step deploy — important)

Pushing `firebase/**` to `main` auto-deploys rules (~1 min for new requests, up to ~10 min for active listeners; no native rollback — revert + re-push). To guarantee no existing read ever breaks:

1. Merge **this PR** (additive; `articles` stays permissive). Prefer a **merge commit** so the follow-up flip PR keeps a minimal diff.
2. Deploy warg workers in order **logger → monolith → workflow → gateway** (gateway last; its new `MONOLITH` service binding needs the monolith deploy target). Deploy the dashboard API and confirm the app fetches archives via `/app/signed-url`.
3. Run the marker backfill with `--apply` for the primary account, then run the coverage gate until it exits 0.
4. **Only then** merge the follow-up flip PR (gates `articles` `get` on markers, denies `list`).
5. GCS IAM lockdown strictly last: remove `allAuthenticatedUsers` from the archive bucket and enforce Public Access Prevention (full runbook in `firebase/README.md`, which lands complete with the flip PR).

Rollback at any point: revert the offending commit and push — the prior ruleset redeploys automatically.

## Risks / caveats

- **In-flight archive jobs at deploy time** keep their data in legacy per-request logger DOs; their live status/SSE freezes for up to ~P99 180s (manifest finalization survives via a legacy fallback). Bounded and accepted.
- **Hour-bucket DO contention** under burst: measured ~2,500× headroom at current write volume; revisit at ~10× growth.
- **Flip-before-backfill breakage** is the failure mode this PR split exists to prevent; the coverage gate hard-blocks and self-heal is a second net.
- A handful of secondary test accounts are not backfilled; their old articles recover lazily via self-heal after the flip.
- Quota-budget-exhausted workflow runs fail with a documented error and need manual resubmission (same class as the previous retry config).

## Follow-up work

- Android lint: 4 pre-existing errors in files untouched by this branch (needs a lint baseline or a separate cleanup).
- Add `firebase/test/.gitignore` (node_modules, emulator debug log).
- Logger POST routes: return 400 (not 500) on malformed payloads; guard empty-string request IDs on the batch route.
- Container instance-type downsize (standard-1 → basic/lite) once peak memory is known.
- Sweep for quota-exhausted (failed-stage) workflow runs.
- Firebase App Check — separate hardening track.
- Residual dev-only CVEs in `firebase/test` tooling (vitest UI-server vector; never active in CI).

## Reviewer focus areas

- `LoggerDO.appendEvents`: single-transaction batch + the guard preventing a post-transaction D1 update from overwriting a racing terminal event's index row.
- `coverage-gate`: `--limit` rejection so a partial scan can never report "safe to flip".
- `storage.rules`: `/archives/**` read denial — the signed-URL endpoint must be the only archive read path.
- `signed-url-core`: bucket-match assertion on `gs://` paths, structured 502 on signing failure, no URL logging.
- The `articles` rule in this PR is **intentionally permissive** — the tightening is the follow-up PR.

## Related

Flip follow-up (draft, merge last after its gate checklist): #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-user signed URLs for secure archive downloads; dashboard exposes signed-URL endpoint
  * Remote Config support for dashboard API base URL

* **Improvements**
  * Archive access tightened to owner-scoped reads; debug log storage scoped to owners
  * Android: removed obsolete Google storage consent flow; self-heal and retry for archive metadata

* **Bug Fixes / CI**
  * CI: stricter lint/test enforcement and earlier Firebase deploy validation; emulator-based rules tests on PRs

* **Documentation**
  * Expanded Firebase and backfill operational guides and migration notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->