### PR TITLE
Flip articles read rule to per-user markers

### DIFF
--- a/firebase/README.md
+++ b/firebase/README.md
@@ -28,16 +28,102 @@ firebase deploy --only firestore:rules,storage
 
 ## Article markers & sequenced read tightening
 
-The top-level `articles` read rule is intentionally still `isAuthenticated()`.
-Tightening it to a marker-gated, get-only read is a **later, separately
-deployed** change: it can only land once every saved article has a per-user
-existence marker at `users/{uid}/articleMarkers/{key}` (see
-[`../shared-types/MarkerSchema.md`](../shared-types/MarkerSchema.md)).
+The top-level `articles` read rule is **marker-gated**: an authenticated user may
+`get articles/{itemId}` only if they hold a per-user existence marker at
+`users/{uid}/articleMarkers/{itemId}` (i.e. they saved that article).
+Enumeration (`list`) is disabled and client `write` stays backend-only (see
+[`../shared-types/MarkerSchema.md`](../shared-types/MarkerSchema.md)):
+
+```
+match /articles/{itemId} {
+  allow get:   if isAuthenticated()
+               && exists(/databases/$(database)/documents/users/$(request.auth.uid)/articleMarkers/$(itemId));
+  allow list:  if false;
+  allow write: if false;  // Backend service account only
+}
+```
 
 Markers are written by the Android client on every sync/backup and on
-read-denial self-heal; historical articles are covered by a one-off backfill.
-Because rules auto-deploy on push to `main`, the read-tightening commit must be
-the **last** to merge so reads keep working until coverage is in place.
+read-denial self-heal; historical articles are covered by a one-off backfill
+(`@warg/backfill-scripts`). Because rules auto-deploy on push to `main`, this
+tightening **must be the last change to merge**, and only after every saved
+article for the active user has a marker — otherwise reads break.
+
+### Two-push deploy sequence (load-bearing — the tightening is fail-safe only in this order)
+
+The marker infrastructure (the `articleMarkers` / owner-scoped `debug_logs`
+rules, the Android marker writes + self-heal, and the emulator harness) is
+**additive and deploy-safe**: it leaves the `articles` read permissive. The
+read-flip is the only breaking change, so it is split off as its own push:
+
+1. **Push 1 — additive infrastructure.** Merge everything *except* the read-flip
+   commit. `firebase-rules.yml` runs the emulator suite then deploys the
+   still-permissive ruleset (`articles` read = `isAuthenticated()`). No reads
+   break.
+2. **Run the prod backfill + wait for the coverage gate to go green** against the
+   deployed infra (runbook:
+   [`../warg/cloud-functions/backfill-scripts/README.md`](../warg/cloud-functions/backfill-scripts/README.md)):
+   ```bash
+   marker-backfill --user <uid> --apply     # writes only-missing markers; idempotent, never deletes
+   coverage-gate   --user <uid>             # must exit 0 (markers ≥ every derived article key)
+   ```
+   The gate is a **hard precondition**: do not proceed until it exits 0.
+3. **Push 2 — the read-flip commit alone.** Merge the `firestore.rules` flip.
+   `firebase-rules.yml` runs the suite (now including the tightened `articles`
+   matrix) then deploys the tightened rule. Propagation: ~1 min for new requests,
+   up to ~10 min for active listeners.
+
+### Prior-ruleset snapshot (rollback reference)
+
+Live `trails-e428e` Firestore ruleset captured **2026-06-09T16:00Z**, before any
+of this branch deployed (flat `debug_logs`, no `articleMarkers` — the pre-branch
+prod state). Recorded as the recovery reference:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAuthenticated() { return request.auth != null; }
+    function isOwner(userId) { return isAuthenticated() && request.auth.uid == userId; }
+
+    match /articles/{itemId} {
+      allow read: if isAuthenticated();
+      allow write: if false;  // Backend service account only
+    }
+    match /debug_logs/{sessionId} {
+      allow read, write: if isAuthenticated();
+      match /entries/{entryId} { allow read, write: if isAuthenticated(); }
+    }
+    match /users/{userId} {
+      allow read, write: if isOwner(userId);
+      match /articles/{articleId} {
+        allow read, write: if isOwner(userId);
+        match /tags/{tagId}            { allow read, write: if isOwner(userId); }
+        match /images/{imageId}        { allow read, write: if isOwner(userId); }
+        match /videos/{videoId}        { allow read, write: if isOwner(userId); }
+        match /authors/{authorId}      { allow read, write: if isOwner(userId); }
+        match /domainMetadata/{metadataId} { allow read, write: if isOwner(userId); }
+      }
+      match /settings/{settingId} { allow read, write: if isOwner(userId); }
+    }
+  }
+}
+```
+
+### Rollback
+
+Firestore rules have **no native rollback** — redeploy the prior ruleset by
+reverting and re-pushing:
+
+```bash
+git revert <read-flip-commit>   # restores the post-push-1 ruleset (articles read permissive again)
+git push origin main            # firebase-rules.yml redeploys it (~1 min new / ~10 min listeners)
+```
+
+`git revert` of the flip commit restores the **push-1** ruleset (additive infra
+present, `articles` read permissive) — the correct fail-safe state, since markers
+remain in place. The snapshot above is the deeper pre-branch baseline, kept only
+as a recovery reference if a full rollback is ever needed.
 
 ## Archive content reads (GCS bucket lockdown)
 

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -12,12 +12,15 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
-    // Top-level articles collection (written by Warg backend, read-only for app)
-    // NOTE: read is intentionally still `isAuthenticated()` — the marker-gated
-    // get-only tightening (and `list: if false`) is a later, separately
-    // deployed change once per-user markers are written and backfilled.
+    // Top-level articles collection (written by Warg backend, read-only for app).
+    // A user may `get` a dedup doc only if they hold a per-user existence marker
+    // for that key (i.e. they saved that article). Enumeration is disabled; writes
+    // are backend-only. Markers: users/{uid}/articleMarkers/{key} (written by sync,
+    // the one-off backfill, and read-denial self-heal).
     match /articles/{itemId} {
-      allow read: if isAuthenticated();
+      allow get:   if isAuthenticated()
+                   && exists(/databases/$(database)/documents/users/$(request.auth.uid)/articleMarkers/$(itemId));
+      allow list:  if false;
       allow write: if false;  // Backend service account only
     }
 

--- a/firebase/test/firestore-rules.test.ts
+++ b/firebase/test/firestore-rules.test.ts
@@ -8,7 +8,7 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { doc, getDoc, setDoc, writeBatch } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, setDoc, writeBatch } from 'firebase/firestore';
 import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +41,11 @@ afterAll(async () => {
 const ownerDb = () => testEnv.authenticatedContext(OWNER).firestore();
 const otherDb = () => testEnv.authenticatedContext(OTHER).firestore();
 const anonDb = () => testEnv.unauthenticatedContext().firestore();
+// Signed-in but via Anonymous Auth (request.auth != null, sign_in_provider 'anonymous').
+const anonAuthDb = () =>
+  testEnv
+    .authenticatedContext('anon-uid', { firebase: { sign_in_provider: 'anonymous' } })
+    .firestore();
 
 describe('articleMarkers (users/{uid}/articleMarkers/{key})', () => {
   // ── reads ────────────────────────────────────────────────────────────────
@@ -234,14 +239,60 @@ describe('debug_logs (debug_logs/{uid}/sessions/{sessionId})', () => {
   });
 });
 
-describe('articles read rule (unchanged this slice)', () => {
-  it('an authenticated user can still read a top-level article (deploy-safety)', async () => {
-    await testEnv.withSecurityRulesDisabled(async (ctx) => {
-      await setDoc(doc(ctx.firestore(), 'articles/article-1'), { title: 'hello' });
+describe('articles (top-level get/list/write matrix)', () => {
+  // Seed a top-level article and (optionally) the owner's existence marker for it.
+  const seedArticle = (itemId: string, withOwnerMarker: boolean) =>
+    testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `articles/${itemId}`), { title: 'hello' });
+      if (withOwnerMarker) {
+        await setDoc(doc(db, `users/${OWNER}/articleMarkers/${itemId}`), {
+          key: itemId,
+          source: 'backfill',
+        });
+      }
     });
-    const db = ownerDb();
-    await assertSucceeds(getDoc(doc(db, 'articles/article-1')));
-    // The marker-gated get-only / `list: if false` tightening and its full
-    // get/list matrix are a later, separately deployed change — not asserted here.
+
+  it('get: owner WITH a marker can read the article', async () => {
+    // Seed BOTH the article and the marker — a marker without the article would
+    // "pass" the rule but return an empty read, which is not a meaningful success.
+    await seedArticle('article-1', true);
+    await assertSucceeds(getDoc(doc(ownerDb(), 'articles/article-1')));
+  });
+
+  it('get: owner WITHOUT a marker is denied', async () => {
+    await seedArticle('article-2', false);
+    await assertFails(getDoc(doc(ownerDb(), 'articles/article-2')));
+  });
+
+  it('get: a different signed-in user (no marker) is denied', async () => {
+    await seedArticle('article-1', true); // owner's marker exists, other's does not
+    await assertFails(getDoc(doc(otherDb(), 'articles/article-1')));
+  });
+
+  it('get: an anonymous-auth user (no marker) is denied', async () => {
+    await seedArticle('article-1', false);
+    await assertFails(getDoc(doc(anonAuthDb(), 'articles/article-1')));
+  });
+
+  it('get: an unauthenticated user is denied', async () => {
+    await seedArticle('article-1', false);
+    await assertFails(getDoc(doc(anonDb(), 'articles/article-1')));
+  });
+
+  it('list: collection queries are denied for every actor', async () => {
+    await seedArticle('article-1', true);
+    await assertFails(getDocs(collection(ownerDb(), 'articles')));
+    await assertFails(getDocs(collection(anonAuthDb(), 'articles')));
+    await assertFails(getDocs(collection(anonDb(), 'articles')));
+  });
+
+  it('list: a signed-in non-owner (no marker) is denied a collection query', async () => {
+    await seedArticle('article-1', true); // owner has a marker; OTHER does not
+    await assertFails(getDocs(collection(otherDb(), 'articles')));
+  });
+
+  it('write: client writes to articles stay denied', async () => {
+    await assertFails(setDoc(doc(ownerDb(), 'articles/article-1'), { title: 'nope' }));
   });
 });


### PR DESCRIPTION
# Flip: gate `articles` reads on per-user markers

The final step of the access-hardening rollout. `match /articles/{itemId}` changes from `allow read: if isAuthenticated()` to:

- `allow get` only when `users/{uid}/articleMarkers/{itemId}` exists,
- `allow list: if false` (no enumeration),
- `allow write: if false` (backend-only, unchanged).

Also includes the full 7-case emulator get/list/write matrix (owner-with-marker succeeds; owner-without-marker, other-user, anonymous-auth, and unauthenticated all denied; list denied for every actor; client writes denied) and the deploy runbook update in `firebase/README.md` (two-push sequence, coverage-gate precondition, prior-ruleset snapshot, revert-and-repush rollback).

## ⚠️ Merge gate — do NOT merge until every box is checked

Merging this PR auto-deploys the tightened rule to production (~1 min for new requests). Merging early makes existing saved articles unreadable for any user without backfilled markers (self-heal recovers single reads lazily, but is a safety net — not the plan).

- [ ] Groundwork PR #27 is merged and its rules deploy succeeded
- [ ] Dashboard API deployed; app confirmed fetching archives via `/app/signed-url`
- [ ] Marker backfill run with `--apply` for the primary account (~22,799 markers)
- [ ] Coverage gate exits 0 (reports COVERED)
- [ ] This PR's base retargeted from the groundwork branch to `main`

## Rollback

No native rules rollback exists: `git revert` this commit and push to `main` — the prior (permissive-read, markers-in-place) ruleset redeploys automatically. The pre-branch baseline ruleset snapshot is kept in `firebase/README.md` as a deeper reference.

## Verification

- Emulator rules suite **22/22** green at this tree — the full `articles` get/list/write matrix together with the groundwork's ownership-gated marker rules (markers can no longer be self-minted for unowned articles, so the flip's "only what you saved" guarantee holds end-to-end).
- Ruleset validates clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Formalized article access control deployment procedure with clear step-by-step guidance, including validation and coverage checks
  * Added rollback procedures with recovery reference

* **Bug Fixes**
  * Restricted article read access to require user verification

* **Tests**
  * Expanded test coverage for article access across different user roles and permission scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->